### PR TITLE
refactoring and adding SCL passenger support

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+# relabel foreman
 /sbin/restorecon -rvvi /usr/share/foreman \
   /var/lib/foreman \
+  /var/run/foreman \
   /var/log/foreman \
   /etc/foreman \
   /etc/sysconfig/foreman \
   /etc/rc.d/init.d/foreman \
   /etc/logrotate.d/foreman \
   /etc/cron.d/foreman
+
+# relabel SCL mod_passenger if found
+[ -d /opt/rh/ruby193/ ] && /sbin/restorecon -rvvi \
+  /opt/rh/ruby193/root/usr/share/gems/gems/passenger-* \
+  /usr/lib/ruby/gems/1.8/gems/passenger-*

--- a/foreman.fc
+++ b/foreman.fc
@@ -1,5 +1,40 @@
-foreman		                 --	gen_context(system_u:object_r:httpd_foreman_script_exec_t,s0)
-/var/log/foreman(/.*)?                  gen_context(system_u:object_r:httpd_foreman_script_log_t,s0)
-/var/lib/foreman/db/(.*.sqlite3)?       gen_context(system_u:object_r:foreman_db_t,s0)
-/usr/share/foreman(/.*)?                gen_context(system_u:object_r:httpd_foreman_script_exec_t,s0)
+# vim: sw=4:ts=4:et
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This program and entire repository is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see http://www.gnu.org/licenses/.
+#
+
+# Foreman file contexts
+
 /etc/foreman(/.*)?                      gen_context(system_u:object_r:foreman_config_t,s0)
+
+/var/lib/foreman(/.*)?                  gen_context(system_u:object_r:foreman_lib_t,s0)
+/var/lib/foreman/db/(.*.sqlite3)?       gen_context(system_u:object_r:foreman_db_t,s0)
+
+/var/log/foreman(/.*)?                  gen_context(system_u:object_r:foreman_log_t,s0)
+
+/var/run/foreman(/.*)?                  gen_context(system_u:object_r:foreman_var_run_t,s0)
+
+/usr/share/foreman/script(/.*)?         gen_context(system_u:object_r:httpd_foreman_script_exec_t,s0)
+
+# Passenger non-SCL file contexts
+
+/usr/lib/ruby/gems/1.8/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/lib/ruby/gems/1.8/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
+
+# Passenger SCL file contexts
+
+/opt/rh/ruby193/root/usr/share/gems/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/opt/rh/ruby193/root/usr/share/gems/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)

--- a/foreman.te
+++ b/foreman.te
@@ -1,32 +1,47 @@
+# vim: sw=4:ts=4:et
+#
+# Copyright 2013 Red Hat, Inc.
+#
+# This program and entire repository is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see http://www.gnu.org/licenses/.
+#
+
 policy_module(foreman, @@VERSION@@)
 
-require {
-  type setfiles_t;
-  type passenger_t;
-  type passenger_tmp_t;
-  type passenger_log_t;
-  type unconfined_t;
-  type httpd_t;
-  type devpts_t;
-  type exim_exec_t;
-  type hostname_exec_t;
-  type puppetmaster_exec_t;
-  type var_log_t;
-  type mysqld_var_run_t;
-  type mysqld_safe_t;
-  type mysqld_t;
-  type mysqld_db_t;
-  type postfix_exec_t;
-  type sendmail_exec_t;
-  type syslogd_t;
-  type sshd_t;
-  type ssh_port_t;
-}
+#######################################
+#
+# Declarations
+#
+# Note: Some mod_passanger 4.0+ processes are running under httpd_t domain,
+# therefore we need to keep two domains: passenger_t and httpd_t.
+#
 
+## <desc>
+## <p>
+## Allow passenger to run foreman.
+## </p>
+## </desc>
+gen_tunable(passenger_run_foreman, true)
+
+## <desc>
+## <p>
+## Allow passenger (httpd_t domain) to run foreman.
+## </p>
+## </desc>
+gen_tunable(httpd_run_foreman, true)
+
+# define types for foreman scripts
 apache_content_template(foreman)
-
-files_read_etc_files(httpd_foreman_script_t)
-miscfiles_read_localization(httpd_foreman_script_t)
 
 # Some basic aliases for different aspects of the filesystem to make things
 # more clear.
@@ -35,57 +50,116 @@ typealias etc_t alias foreman_config_t;
 type foreman_db_t;
 files_type(foreman_db_t)
 
+type foreman_lib_t;
+files_type(foreman_lib_t)
+
+type foreman_log_t;
+typealias foreman_log_t alias httpd_foreman_script_log_t;
+logging_log_file(foreman_log_t)
+
+type foreman_var_run_t;
+files_pid_file(foreman_var_run_t)
+
+require{
+    type httpd_t;
+    type passenger_t;
+    type passenger_tmp_t;
+    type puppetmaster_exec_t;
+    type puppetmaster_t;
+}
+
+#######################################
+#
+# Foreman local policy
+#
+
+manage_dirs_pattern(httpd_foreman_script_t, foreman_lib_t , foreman_lib_t)
+manage_dirs_pattern(httpd_foreman_script_t, foreman_lib_t , foreman_lib_t)
+
+manage_files_pattern(httpd_foreman_script_t, foreman_log_t , foreman_log_t)
+
+manage_files_pattern(httpd_foreman_script_t, foreman_var_run_t , foreman_var_run_t)
+
+files_read_etc_files(httpd_foreman_script_t)
+
 logging_send_syslog_msg(httpd_foreman_script_t)
-type httpd_foreman_script_log_t;
-logging_log_file(httpd_foreman_script_log_t)
 
-# Allow Foreman to write to the SQlite databases
-allow passenger_t foreman_db_t:dir { search append };
-allow passenger_t foreman_db_t:file { write read open getattr create };
+miscfiles_read_localization(httpd_foreman_script_t)
 
-# httpd needs to write to local sockets
-allow httpd_t passenger_tmp_t:sock_file write;
-
-# Allow access to pseudo terminal devices to connect to local virt.
-allow passenger_t devpts_t:dir search;
-
-# Allow sending of email reports.
-allow passenger_t exim_exec_t:file { getattr execute };
-allow passenger_t sendmail_exec_t:file { getattr execute };
-allow passenger_t postfix_exec_t:file { getattr execute };
-
-# This is required for local MTA's to send mail from the machine.
-allow passenger_t hostname_exec_t:file { read getattr open execute execute_no_trans };
-
-allow passenger_t passenger_tmp_t:sock_file { write create unlink getattr setattr };
-
-# Allow passenger to interact with the master.
-allow passenger_t puppetmaster_exec_t:file { read getattr open execute execute_no_trans };
+#######################################
+#
+# Passanger/httpd local policy
+#
 
 allow passenger_t self:capability sys_resource;
+allow passenger_t self:process signull;
+allow passenger_t self:tcp_socket listen;
+
+miscfiles_read_localization(passenger_t)
+
+corenet_tcp_connect_postgresql_port(passenger_t)
+corenet_tcp_connect_ssh_port(passenger_t)
 
 # The read the code (and potentially modules) from /usr/share.
-allow passenger_t usr_t:dir { open read getattr };
-allow passenger_t usr_t:file { open read getattr };
+files_read_usr_files(passenger_t)
 
-# Allow Foreman to write to /var/log
-allow passenger_t var_log_t:file { open append getattr };
+# Allow access to pseudo terminal devices to connect to local virt.
+term_search_ptys(passenger_t)
 
-allow passenger_t mysqld_db_t:dir search;
-allow passenger_t mysqld_safe_t:dir { getattr search };
-allow passenger_t mysqld_safe_t:file { read open };
-allow passenger_t mysqld_t:dir { getattr search };
-allow passenger_t mysqld_t:file { read open };
-allow passenger_t mysqld_var_run_t:sock_file write;
-allow passenger_t mysqld_t:unix_stream_socket connectto;
+# For memory-statistics script which executes /usr/bin/free
+files_exec_usr_files(passenger_t)
 
-allow passenger_t httpd_foreman_script_exec_t:dir { read search open getattr };
-allow passenger_t httpd_foreman_script_exec_t:file { read getattr open };
-allow passenger_t httpd_foreman_script_exec_t:lnk_file read;
+optional_policy(`
+    tunable_policy(`passenger_run_foreman', `
+        read_files_pattern(httpd_t, foreman_lib_t, foreman_lib_t)
+        manage_files_pattern(passenger_t, foreman_lib_t, foreman_lib_t)
+        manage_dirs_pattern(passenger_t, foreman_lib_t, foreman_lib_t)
+        manage_files_pattern(passenger_t, foreman_var_run_t, foreman_var_run_t)
+        manage_dirs_pattern(passenger_t, foreman_var_run_t, foreman_var_run_t)
+        # Allow Foreman to write to the SQlite databases
+        read_files_pattern(passenger_t, foreman_db_t, foreman_db_t)
+        write_files_pattern(passenger_t, foreman_db_t, foreman_db_t)
+    ')
+')
 
-allow passenger_t syslogd_t:dir { getattr search };
+optional_policy(`
+    tunable_policy(`passenger_run_foreman', `
+        read_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
+        read_lnk_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
+        append_files_pattern(passenger_t, foreman_log_t, foreman_log_t)
+        ')
+')
 
-allow passenger_t sshd_t:file { read open };
-allow passenger_t ssh_port_t:tcp_socket name_connect;
 
-allow passenger_t self:tcp_socket listen;
+optional_policy(`
+    tunable_policy(`passenger_run_foreman', `
+        allow passenger_t self:process getsession;
+        fs_rw_anon_inodefs_files(passenger_t)
+        allow passenger_t httpd_t:unix_stream_socket getattr;
+    ')
+')
+
+tunable_policy(`httpd_run_foreman', `
+    allow httpd_t passenger_tmp_t:sock_file write;
+')
+
+optional_policy(`
+    # Allow sending of email reports.
+    mta_send_mail(passenger_t)
+')
+
+optional_policy(`
+    mysql_stream_connect(passenger_t)
+    mysql_list_db(passenger_t)
+')
+
+optional_policy(`
+    hostname_exec(passenger_t)
+')
+
+optional_policy(`
+    # Transition to puppet_master
+    corecmd_search_bin(passenger_t)
+    domtrans_pattern(passenger_t, puppetmaster_exec_t, puppetmaster_t)
+')
+


### PR DESCRIPTION
One, policy was refactored with respect of recent changes in RHEL 6.4+ base
policy (passenger_t and httpd_t domains).

Two, we added SCL passenger support. There are two steps:

a) In foreman.fc we added file contexts in /opt/rh/ruby193/...

b) During installation, in the foreman-selinux-relabel, we relabel this
directory recursively.

Please test with SCL and without SCL mod_passenger and report AVC logs here.
