### PR TITLE
Fix concurrent execution of the release script during Jenkins builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 TAGS
+pkg/

--- a/release
+++ b/release
@@ -17,13 +17,15 @@ DIST=$2
 
 git describe $VERSION &>/dev/null || echo "WARNING! There is no such tag: $VERSION!"
 
+RPMBUILD=$(pwd)/pkg/rpmbuild
 TEMPDIR=$(mktemp -d)
 trap "rm -rf $TEMPDIR" EXIT
-mkdir $TEMPDIR/$PROJECT-$VERSION
+mkdir -p $TEMPDIR/$PROJECT-$VERSION $RPMBUILD/SOURCES
 cp -Rad . $TEMPDIR/$PROJECT-$VERSION
+
 pushd $TEMPDIR
 rm -rf `find -name ".git*"`
-tar c $PROJECT-$VERSION | gzip -9 > ~/rpmbuild/SOURCES/$PROJECT-$VERSION.tar.gz
+tar c $PROJECT-$VERSION | gzip -9 > $RPMBUILD/SOURCES/$PROJECT-$VERSION.tar.gz
 cd $PROJECT-$VERSION
-rpmbuild -bs $PROJECT.spec --define "dist $DIST"
+rpmbuild -bs $PROJECT.spec --define "dist $DIST" --define "_topdir $RPMBUILD"
 popd


### PR DESCRIPTION
Should fix the invalid SRPMS and tarballs being uploaded to koji, which were
failing with CRC errors as Jenkins runs 2/3 of these in parallel for
different dists.

Counterpart to https://github.com/theforeman/foreman-installer/pull/76
