### PR TITLE
Katello selinux policy and other fixes

### DIFF
--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -1,11 +1,16 @@
 #!/bin/bash
 
-# install policy modules in one transaction
 for selinuxvariant in targeted
 do
-  /usr/sbin/semodule -s $selinuxvariant -l >/dev/null 2>&1 && \
-  /usr/sbin/semanage -S $selinuxvariant -i - << _EOF
-  module -a /usr/share/selinux/${selinuxvariant}/foreman.pp.bz2
-  boolean -m --on httpd_setrlimit
-_EOF
+  if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
+    # TRANSACTION 1
+    /usr/sbin/semanage -S $selinuxvariant -i - << _EOT1
+      module -a /usr/share/selinux/${selinuxvariant}/foreman.pp.bz2
+      boolean -m --on httpd_setrlimit
+_EOT1
+    # TRANSACTION 2
+    /usr/sbin/semanage -S $selinuxvariant -i - << _EOT2
+      port -a -t elasticsearch_port_t -p tcp 9200-9300
+_EOT2
+  fi
 done

--- a/foreman.te
+++ b/foreman.te
@@ -267,10 +267,11 @@ require {
     type vnc_port_t;
 }
 
-allow websockify_t self:netlink_route_socket { bind create getattr nlmsg_read };
-allow websockify_t self:tcp_socket { setopt bind create listen accept connect shutdown };
-allow websockify_t self:udp_socket { getattr ioctl create connect };
+allow websockify_t self:netlink_route_socket { all_netlink_route_socket_perms };
+allow websockify_t self:tcp_socket { all_tcp_socket_perms };
+allow websockify_t self:udp_socket { all_udp_socket_perms };
 
+apache_search_config(websockify_t)
 corenet_tcp_bind_generic_node(websockify_t)
 corenet_tcp_connect_vnc_port(websockify_t)
 corenet_tcp_bind_vnc_port(websockify_t)

--- a/foreman.te
+++ b/foreman.te
@@ -183,7 +183,8 @@ optional_policy(`
     tunable_policy(`passenger_run_foreman', `
         read_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
         read_lnk_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
-        append_files_pattern(passenger_t, foreman_log_t, foreman_log_t)
+        # unfortunately rails does not only append but also read and write
+        rw_files_pattern(passenger_t, foreman_log_t, foreman_log_t)
         ')
 ')
 
@@ -279,6 +280,30 @@ logging_send_syslog_msg(websockify_t)
 miscfiles_read_localization(websockify_t)
 sysnet_read_config(websockify_t)
 abrt_stream_connect(websockify_t)
+
+######################################
+#
+# Elasticsearch
+#
+
+# We carry elasticsearch policy until it is delivered to RHEL6:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1102119
+type elasticsearch_port_t;
+corenet_port(elasticsearch_port_t)
+
+######################################
+#
+# Foreman Katello plugin
+#
+
+# System status (ping) controller checks for service status using sysvinit scripts
+# This is temporary solution until https://bugzilla.redhat.com/show_bug.cgi?id=1105085
+# is fixed.
+init_exec_script_files(passenger_t)
+consoletype_exec(passenger_t)
+
+# Katello does connect to Elasticsearch services
+allow passenger_t elasticsearch_port_t:tcp_socket name_connect;
 
 ######################################
 #


### PR DESCRIPTION
After week of Satellite 6 testing, it looks like we only miss those rules.

I was not able to find out what is spawning the `consoletype` binary. Searched
most of our plugins, Foreman, Katello, tog, passenger itself. But it looks
harmless - only returns console type, it has it's own domain which is safe
enough.

There is still one bug - something binds _random_ udp port. Open topic.
