### PR TITLE
fixes #5930 - fix katello-jobs domain

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -2,6 +2,7 @@
 
 # relabel foreman
 /sbin/restorecon -ri $* /usr/share/foreman \
+  /usr/share/katello \
   /var/lib/foreman \
   /var/run/foreman \
   /var/log/foreman \

--- a/foreman.fc
+++ b/foreman.fc
@@ -50,3 +50,7 @@
 
 /usr/share/gems/gems/foreman-tasks-*/bin/foreman-tasks -- gen_context(system_u:object_r:foreman_tasks_exec_t,s0)
 /opt/rh/ruby193/root/usr/share/gems/gems/foreman-tasks-.*/bin/foreman-tasks -- gen_context(system_u:object_r:foreman_tasks_exec_t,s0)
+
+# Katello plugin
+
+/usr/share/katello/script/katello-jobs -- gen_context(system_u:object_r:foreman_tasks_exec_t,s0)


### PR DESCRIPTION
Fix for my previous commit, katello has an extra wrapper for foreman tasks.

https://bugzilla.redhat.com/show_bug.cgi?id=1084919

@domcleal - can I ask you for quick merge to hit the next snap? ty
