### PR TITLE
Fixes #7198 - allowed httpd_t to read/write to passenger socket

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -191,7 +191,7 @@ optional_policy(`
     tunable_policy(`passenger_run_foreman', `
         allow passenger_t self:process getsession;
         fs_rw_anon_inodefs_files(passenger_t)
-        allow passenger_t httpd_t:unix_stream_socket getattr;
+        allow passenger_t httpd_t:unix_stream_socket { read write getattr };
         fs_getattr_xattr_fs(passenger_t)
         ifdef(`distro_rhel7', `
             allow passenger_t self:capability2 block_suspend;


### PR DESCRIPTION
SSIA

If I can have quick look on both patches.
