### PR TITLE
Refs #7178 - removed passenger_t execmem rule

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -347,7 +347,3 @@ typealias bin_t alias foreman_hook_t;
 # the plugin daemon uses daemon gem for the backround job
 type foreman_tasks_exec_t;
 init_daemon_domain(passenger_t, foreman_tasks_exec_t)
-# dynflow executor currently runs in foreman_t because
-# it boots the whole rails environment
-# http://projects.theforeman.org/issues/7178
-allow passenger_t self:process execmem;


### PR DESCRIPTION
This reverts commit d867377e56451fc43030a30958499d34e6f4e485.

Introduced here: https://github.com/theforeman/foreman-selinux/pull/28

Not required because: https://github.com/Katello/katello/pull/4673
