### PR TITLE
fixes #7729 - allow websockify to read certs

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -331,6 +331,9 @@ ifndef(`distro_rhel7', `
 # Katello does connect to Elasticsearch services
 allow passenger_t elasticsearch_port_t:tcp_socket name_connect;
 
+# Katello uses certs in /etc/pki/katello for websockets
+miscfiles_read_certs(websockify_t)
+
 ######################################
 #
 # Foreman Bootdisk plugin


### PR DESCRIPTION
This is definitely needed for Katello because our certs are in `/etc/pki`.
