### PR TITLE
Fixes #8683 - allowed Celery port for Katello

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -393,6 +393,13 @@ allow passenger_t elasticsearch_port_t:tcp_socket name_connect;
 # Katello uses certs in /etc/pki/katello for websockets
 miscfiles_read_certs(websockify_t)
 
+# Katello installer configures Pulp to listen on port 5000
+ifdef(`distro_rhel6', `
+    corenet_tcp_bind_commplex_port(passenger_t)
+',`
+    corenet_tcp_bind_commplex_main_port(passenger_t)
+')
+
 ######################################
 #
 # Foreman Bootdisk plugin


### PR DESCRIPTION
Not introducing boolean for this one, I want to extract all the Katello bit
into separate module post 6.1.
