### PR TITLE
Fixes #8989 - Add docker_port_t port and boolean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VARIANT=targeted
 TYPE=apps
 VERSION=99.999
 MANCHAPTER=Foreman
-TMPDIR=local-tmp
+TMPDIR=local-tmp-foreman
 
 ifndef DISTRO
 $(error Set the DISTRO variable e.g. rhel7 or fedora21)
@@ -97,8 +97,8 @@ consolidate-installation:
 
 remote-load:
 ifdef HOST
-	-rsync -qrav . -e ssh --exclude .git ${HOST}:policy/
-	ssh ${HOST} 'cd policy && sed -i s/@@VERSION@@/${VERSION}/ *.te && make -f /usr/share/selinux/devel/Makefile load DISTRO=${DISTRO}'
+	-rsync -qrav . --delete -e ssh --exclude .git ${HOST}:${TMPDIR}/
+	ssh ${HOST} 'cd ${TMPDIR} && sed -i s/@@VERSION@@/${VERSION}/ *.te && make -f /usr/share/selinux/devel/Makefile load DISTRO=${DISTRO}'
 else
 	$(error You need to define your remote ssh hostname as HOST)
 endif

--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -9,7 +9,7 @@ do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
     # Remove all user defined ports (including the default one)
     /usr/sbin/semanage port -E | \
-      grep elasticsearch_port_t | \
+      grep -E '(elasticsearch|docker)_port_t' | \
       sed s/-a/-d/g | \
       /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -22,6 +22,9 @@ do
     /usr/sbin/semanage port -E | grep -q elasticsearch_port_t || \
       echo "port -a -t elasticsearch_port_t -p tcp 9200-9300" >> $TMP
 
+    /usr/sbin/semanage port -E | grep -q docker_port_t || \
+      echo "port -a -t docker_port_t -p tcp 2375-2376" >> $TMP
+
     /usr/sbin/semanage -S $selinuxvariant -i $TMP
   fi
 done

--- a/foreman.te
+++ b/foreman.te
@@ -64,6 +64,20 @@ gen_tunable(passenger_can_connect_all, false)
 
 ## <desc>
 ## <p>
+## Determine whether passenger can connect to Docker via TCP
+## </p>
+## </desc>
+gen_tunable(passenger_can_connect_docker_tcp, true)
+
+## <desc>
+## <p>
+## Determine whether passenger can connect to Docker via local socket
+## </p>
+## </desc>
+gen_tunable(passenger_can_connect_docker_unix, true)
+
+## <desc>
+## <p>
 ## Determine whether passenger can connect to OpenStack
 ## </p>
 ## </desc>
@@ -362,6 +376,24 @@ sysnet_read_config(websockify_t)
 abrt_stream_connect(websockify_t)
 files_search_var_lib(websockify_t)
 read_files_pattern(websockify_t, puppet_var_lib_t, puppet_var_lib_t)
+
+######################################
+#
+# Docker
+#
+
+type docker_port_t;
+corenet_port(docker_port_t)
+
+tunable_policy(`passenger_can_connect_docker_tcp',`
+    allow passenger_t docker_port_t:tcp_socket name_connect;
+')
+
+tunable_policy(`passenger_can_connect_docker_unix',`
+    ifndef(`distro_rhel6', `
+        docker_stream_connect(passenger_t)
+    ')
+')
 
 ######################################
 #


### PR DESCRIPTION
Boolean passenger_can_connect_docker allows connections to newly created 
docker_port_t which is not yet defined in RHEL7/Fedora. This can be used when
users starts Docker on TCP (defaults to UNIX sockets). IANA assigned 2375 and
2376 ports for http/https communication on 2015-01-09.

Denial:

type=AVC msg=audit(1421352630.245:15331): avc:  denied  { name_connect } for 
pid=4803 comm="ruby" dest=2375 scontext=unconfined_u:system_r:passenger_t:s0 
tcontext=system_u:object_r:port_t:s0 tclass=tcp_socket

@domcleal - in the patch I propose to have that boolean set to `true` by
default to help non-SELinux aware users.
