### PR TITLE
Fixes #10443 - added nova/glance/neutron rules

### DIFF
--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -9,7 +9,7 @@ do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
     # Remove all user defined ports (including the default one)
     /usr/sbin/semanage port -E | \
-      grep -E '(elasticsearch|docker)_port_t' | \
+      grep -E '(elasticsearch|docker|foreman_osapi_compute)_port_t' | \
       sed s/-a/-d/g | \
       /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -4,6 +4,10 @@ set +e
 TMP=$(mktemp -t foreman-selinux-enable.XXXXXXXXXX)
 trap "rm -rf '$TMP'" EXIT INT TERM
 
+is_redhat_6() {
+  test x$(rpm -q --whatprovides redhat-release --qf '%{version}') = x6
+}
+
 # Load or upgrade foreman policy and set booleans.
 #
 # Dependant booleans must be managed in a separate transaction.
@@ -24,6 +28,11 @@ do
 
     /usr/sbin/semanage port -E | grep -q docker_port_t || \
       echo "port -a -t docker_port_t -p tcp 2375-2376" >> $TMP
+
+    if is_redhat_6; then
+      /usr/sbin/semanage port -E | grep -q foreman_osapi_compute_port_t || \
+        echo "port -a -t foreman_osapi_compute_port_t -p tcp 8774" >> $TMP
+    fi
 
     /usr/sbin/semanage -S $selinuxvariant -i $TMP
   fi

--- a/foreman.te
+++ b/foreman.te
@@ -142,6 +142,9 @@ files_pid_file(foreman_var_run_t)
 type foreman_proxy_port_t;
 corenet_port(foreman_proxy_port_t)
 
+type foreman_osapi_compute_port_t;
+corenet_port(foreman_osapi_compute_port_t)
+
 require{
     type bin_t;
     type httpd_t;
@@ -308,9 +311,15 @@ optional_policy(`
 
 tunable_policy(`passenger_can_connect_openstack',`
     ifdef(`distro_rhel6', `
+        # keystone (identity service)
         corenet_tcp_connect_commplex_port(passenger_t)
+        # all other ports not yet defined on rhel6
+        allow passenger_t foreman_osapi_compute_port_t:tcp_socket name_connect;
     ',`
+        # keystone (identity service)
         corenet_tcp_connect_commplex_main_port(passenger_t)
+        # nova (compute service)
+        corenet_tcp_connect_osapi_compute_port(passenger_t)
     ')
 ')
 


### PR DESCRIPTION
Ok I've missed several other ports. The discussion is in the linked BZ.

There is one snag - the commented macro is missing in RHEL6 and we need to,
once again, define our own port. It will likely cause issues because I expect
this one to be introduced in RHEL6. I need to find a way how to deal with this
first. Then let's get back to this.
