### PR TITLE
Fixes #9791 - removed unused apache_template macro and types

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -30,7 +30,6 @@
 
 /usr/share/foreman/.ssh(/.*)?           gen_context(system_u:object_r:ssh_home_t,s0)
 /usr/share/foreman/extras/noVNC/websockify\.py gen_context(system_u:object_r:websockify_exec_t,s0)
-/usr/share/foreman/script(/.*)?         gen_context(system_u:object_r:httpd_foreman_script_exec_t,s0)
 
 # Passenger non-SCL file contexts
 

--- a/foreman.te
+++ b/foreman.te
@@ -97,9 +97,6 @@ gen_tunable(passenger_can_spawn_ssh, true)
 ## </desc>
 gen_tunable(passenger_can_connect_libvirt, true)
 
-# define types for foreman scripts
-apache_content_template(foreman)
-
 # Some basic aliases for different aspects of the filesystem to make things
 # more clear.
 require{
@@ -117,7 +114,6 @@ type foreman_lib_t;
 files_type(foreman_lib_t)
 
 type foreman_log_t;
-typealias foreman_log_t alias httpd_foreman_script_log_t;
 logging_log_file(foreman_log_t)
 
 type foreman_var_run_t;
@@ -144,24 +140,6 @@ require{
     type sysctl_net_t;
     type websm_port_t;
 }
-
-#######################################
-#
-# Foreman local policy
-#
-
-manage_dirs_pattern(httpd_foreman_script_t, foreman_lib_t , foreman_lib_t)
-manage_dirs_pattern(httpd_foreman_script_t, foreman_lib_t , foreman_lib_t)
-
-manage_files_pattern(httpd_foreman_script_t, foreman_log_t , foreman_log_t)
-
-manage_files_pattern(httpd_foreman_script_t, foreman_var_run_t , foreman_var_run_t)
-
-files_read_etc_files(httpd_foreman_script_t)
-
-logging_send_syslog_msg(httpd_foreman_script_t)
-
-miscfiles_read_localization(httpd_foreman_script_t)
 
 #######################################
 #
@@ -227,14 +205,6 @@ optional_policy(`
 
 optional_policy(`
     tunable_policy(`passenger_run_foreman', `
-        read_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
-        read_lnk_files_pattern(passenger_t, httpd_foreman_script_exec_t, httpd_foreman_script_exec_t)
-        manage_files_pattern(passenger_t, foreman_log_t , foreman_log_t)
-        ')
-')
-
-optional_policy(`
-    tunable_policy(`passenger_run_foreman', `
         allow passenger_t self:process getsession;
         fs_rw_anon_inodefs_files(passenger_t)
         allow passenger_t httpd_t:unix_stream_socket { read write getattr };
@@ -253,6 +223,7 @@ tunable_policy(`httpd_run_foreman', `
     manage_dirs_pattern(passenger_t, httpd_tmp_t, httpd_tmp_t)
     manage_files_pattern(passenger_t, httpd_tmp_t, httpd_tmp_t)
     manage_sock_files_pattern(passenger_t, httpd_tmp_t, httpd_tmp_t)
+    manage_files_pattern(passenger_t, foreman_log_t , foreman_log_t)
 ')
 
 optional_policy(`


### PR DESCRIPTION
To be honest, I have absolutely no idea why this was defined. Perhaps for some
earlier versions of Passenger. It looks like without these rules, everything
starts correctly. Tested on both RHEL6 and 7:

```
[root@fsix ~]# ps axuZ | grep passenger_t
unconfined_u:system_r:passenger_t:s0 root 1571  0.0  0.0 214068  1484 ?        Ssl  09:05   0:00 PassengerWatchdog
unconfined_u:system_r:passenger_t:s0 root 1574  0.1  0.0 575848  3008 ?        Sl   09:05   0:00 PassengerHelperAgent
unconfined_u:system_r:passenger_t:s0 nobody 1579 0.0  0.0 214200 2896 ?        Sl   09:05   0:00 PassengerLoggingAgent
unconfined_u:system_r:passenger_t:s0 foreman 1619 0.0  0.0 9232  1088 ?        S    09:05   0:00 /bin/bash /usr/bin/ruby193-ruby /usr/lib/ruby/gems/1.8/gems/passenger-4.0.18/helper-scripts/rack-preloader.rb
unconfined_u:system_r:passenger_t:s0 foreman 1628 0.0  0.0 4060   520 ?        S    09:05   0:00 scl enable ruby193 ruby /usr/lib/ruby/gems/1.8/gems/passenger-4.0.18/helper-scripts/rack-preloader.rb
unconfined_u:system_r:passenger_t:s0 foreman 1629 0.0  0.0 9232  1140 ?        S    09:05   0:00 /bin/bash /var/tmp/sclu57IDC
unconfined_u:system_r:passenger_t:s0 foreman 1632 13.7  5.7 372328 176904 ?    Sl   09:05   0:17 Passenger AppPreloader: /usr/share/foreman                                        
unconfined_u:system_r:passenger_t:s0 foreman 1667 0.3  5.9 507024 184280 ?     Sl   09:05   0:00 Passenger RackApp: /usr/share/foreman                                             
unconfined_u:system_r:passenger_t:s0 foreman 1675 3.6  7.9 638496 246196 ?     Sl   09:05   0:03 Passenger RackApp: /usr/share/foreman                                             
unconfined_u:system_r:passenger_t:s0 puppet 1751 4.3  2.1 157252 67788 ?       Sl   09:06   0:00 Passenger AppPreloader: /etc/puppet/rack                                                   
unconfined_u:system_r:passenger_t:s0 puppet 1769 3.2  3.0 200736 94464 ?       Sl   09:06   0:00 Passenger RackApp: /etc/puppet/rack                                                        
unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 root 2036 0.0  0.0 103256 844 pts/1 S+ 09:07   0:00 grep passenger_t
```

```
[root@fseven ~]# ps axuZ | grep passenger_t
system_u:system_r:passenger_t:s0 root    20069  0.0  0.0 214752  1860 ?        Ssl  09:01   0:00 PassengerWatchdog
system_u:system_r:passenger_t:s0 root    20072  0.1  0.1 569480  3048 ?        Sl   09:01   0:00 PassengerHelperAgent
system_u:system_r:passenger_t:s0 nobody  20080  0.0  0.1 219744  3908 ?        Sl   09:01   0:00 PassengerLoggingAgent
system_u:system_r:passenger_t:s0 foreman 20101  0.0  0.0   9508  1268 ?        S    09:01   0:00 /bin/bash /usr/bin/ruby193-ruby /usr/share/gems/gems/passenger-4.0.18/helper-scripts/rack-preloader.rb
system_u:system_r:passenger_t:s0 foreman 20110  0.0  0.0   4304   568 ?        S    09:01   0:00 scl enable ruby193 ruby /usr/share/gems/gems/passenger-4.0.18/helper-scripts/rack-preloader.rb
system_u:system_r:passenger_t:s0 foreman 20112  0.0  0.0   9508  1316 ?        S    09:01   0:00 /bin/bash /var/tmp/sclH01Cbl
system_u:system_r:passenger_t:s0 foreman 20116 25.2  5.8 399008 178212 ?       Sl   09:01   0:17 Passenger AppPreloader: /usr/share/foreman
system_u:system_r:passenger_t:s0 foreman 20154  0.8  5.9 533068 182492 ?       Sl   09:02   0:00 Passenger RackApp: /usr/share/foreman
system_u:system_r:passenger_t:s0 foreman 20162  1.1  5.9 533072 181884 ?       Sl   09:02   0:00 Passenger RackApp: /usr/share/foreman
unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 root 20202 0.0  0.0 112640 980 pts/1 R+ 09:02   0:00 grep --color=auto passenger_t
```

Both PM and Foreman are running under passenger_t. Any other clues what to
test? I need quick downstream merge for this one, so any idea is appreciated.
