### PR TITLE
Refs #13502 - introduced has_docker definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@ TAGS
 pkg/
 tmp/
 local-tmp/
-*.pp
-*.pp.bz2
+*.pp*
 *.pod
 *.8
 foreman-proxy-selinux-enable

--- a/foreman.te
+++ b/foreman.te
@@ -20,6 +20,19 @@ policy_module(foreman, @@VERSION@@)
 
 #######################################
 #
+# Definitions
+#
+# This defines set of special (unused) types which are used for easier detection
+# what definitions the policy was compiled with. Use seinfo -tTYPE to find
+# particular flag.
+#
+
+ifdef(`has_docker', `
+    type foreman_has_docker_defined_t;
+')
+
+#######################################
+#
 # Declarations
 #
 # Note: Some mod_passanger 4.0+ processes are running under httpd_t domain,
@@ -376,7 +389,7 @@ tunable_policy(`passenger_can_connect_docker_tcp',`
 
 optional_policy(`
     tunable_policy(`passenger_can_connect_docker_unix',`
-        ifndef(`distro_rhel6', `
+        ifdef(`has_docker', `
             docker_stream_connect(passenger_t)
         ')
     ')


### PR DESCRIPTION
This adds `has_docker` variable which is set when `docker.if` file is present.
This is not true on RHEL6 and RHEL 7.2 (as it was moved to separate
`docker-selinux` package there.

We used to have `distro_rhel6` there but we can now use this particular test
instead which is more accurate.

When this is compiled on RHEL 7.2 without the `docker-selinux` installed, it
does not fail. I will proceed with adding BuildRequire for our RPM package to
prevent this. As an indication, I've added special `defined_t` type which can
be used as a flag to easily find out if the `has_docker` support was compiled
in.

The patch also fixes few typos and adds some info messages in Makefile.
