### PR TITLE
Fixes #14811 - passenger paths for RHEL7 fixed

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -16,12 +16,15 @@
   /usr/lib/ruby/gems/1.8/gems/passenger-* \
   /usr/lib64/gems/ruby/passenger-*/agents \
   /usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents \
+  /usr/share/passenger/helper-scripts \
+  /usr/libexec/passenger \
   /var/run/rubygem-passenger
 
 # relabel SCL mod_passenger and foreman plugins if SCL is found
 [ -d /opt/theforeman/tfm/ ] && /sbin/restorecon -ri $* \
   /opt/theforeman/tfm/root/usr/share/gems/gems/passenger-* \
   /opt/theforeman/tfm/root/usr/lib64/gems/exts/passenger-*/agents \
+  /opt/theforeman/tfm/root/usr/lib64/gems/ruby/passenger-*/agents \
   /opt/theforeman/tfm/root/usr/share/gems/gems/foreman*
 
 exit 0

--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -13,18 +13,18 @@
   /etc/rc.d/init.d/foreman* \
   /etc/logrotate.d/foreman* \
   /etc/cron.d/foreman* \
-  /usr/lib/ruby/gems/1.8/gems/passenger-* \
-  /usr/lib64/gems/ruby/passenger-*/agents \
-  /usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents \
+  /usr/lib{64,}/ruby/gems/1.8/gems/passenger-* \
+  /usr/lib{64,}/gems/ruby/passenger-*/agents \
+  /usr/lib{64,}/ruby/site_ruby/1.8/x86_64-linux/agents \
   /usr/share/passenger/helper-scripts \
-  /usr/libexec/passenger \
+  /usr/lib{64,}exec/passenger \
   /var/run/rubygem-passenger
 
 # relabel SCL mod_passenger and foreman plugins if SCL is found
 [ -d /opt/theforeman/tfm/ ] && /sbin/restorecon -ri $* \
   /opt/theforeman/tfm/root/usr/share/gems/gems/passenger-* \
-  /opt/theforeman/tfm/root/usr/lib64/gems/exts/passenger-*/agents \
-  /opt/theforeman/tfm/root/usr/lib64/gems/ruby/passenger-*/agents \
+  /opt/theforeman/tfm/root/usr/lib{64,}/gems/exts/passenger-*/agents \
+  /opt/theforeman/tfm/root/usr/lib{64,}/gems/ruby/passenger-*/agents \
   /opt/theforeman/tfm/root/usr/share/gems/gems/foreman*
 
 exit 0

--- a/foreman.fc
+++ b/foreman.fc
@@ -34,14 +34,19 @@
 # Passenger non-SCL file contexts
 
 /usr/lib/ruby/gems/1.8/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
-/usr/lib64/ruby/site_ruby/1.8/x86_64-linux/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/lib/ruby/site_ruby/1.8/x86_64-linux/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/libexec/passenger/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+
 /usr/lib/ruby/gems/1.8/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/share/passenger/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
+
 /var/run/rubygem-passenger(.*)?         gen_context(system_u:object_r:passenger_var_run_t,s0)
 
-# Passenger SCL file contexts
+# Passenger SCL file contexts (/opt/*/root prefix is distribution equivalence)
 
-/opt/theforeman/tfm/root/usr/(share/gems/gems|lib64/gems/exts)/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
-/opt/theforeman/tfm/root/usr/(share/gems/gems|lib64/gems/exts)/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/share/gems/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/share/gems/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/lib/gems/(exts|ruby)/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
 # Foreman Hooks plugin
 

--- a/foreman.fc
+++ b/foreman.fc
@@ -34,7 +34,7 @@
 # Passenger non-SCL file contexts
 
 /usr/lib/ruby/gems/1.8/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
-/usr/lib/ruby/site_ruby/1.8/x86_64-linux/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/lib6?4?/ruby/site_ruby/1.8/x86_64-linux/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 /usr/libexec/passenger/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
 /usr/lib/ruby/gems/1.8/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
@@ -46,7 +46,7 @@
 
 /usr/share/gems/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 /usr/share/gems/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
-/usr/lib/gems/(exts|ruby)/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
+/usr/lib6?4?/gems/(exts|ruby)/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
 # Foreman Hooks plugin
 


### PR DESCRIPTION
Two changes here. First, the update in EPEL7 changed paths completely.

Second, it looks like tfm SCL now defines a file context root:

```
    rpm -qa --scripts |grep semanage
    ...
    semanage fcontext -a -e / /opt/theforeman/tfm/root
```

Which made our SCL rules invalid, so I prefixed them optionally. Looks like
better solution because it also matches non-SCL files as well.
