### PR TITLE
Fixes #15639 - OpenStack port assigned on RHEL6

### DIFF
--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -7,7 +7,7 @@ TMP_PORTS=$(mktemp -t foreman-selinux-enable.XXXXX)
 trap "rm -rf '$TMP_EXEC_BEFORE' '$TMP_EXEC_AFTER' '$TMP_PORTS'" EXIT INT TERM
 
 is_redhat_6() {
-  test x$(rpm -q --whatprovides redhat-release --qf '%{version}') = x6
+  [[ $(rpm -q --whatprovides redhat-release --qf '%{version}') == 6* ]]
 }
 
 # Load or upgrade foreman policy and set booleans.


### PR DESCRIPTION
Result of the command was "6Server" and not "6" so it failed. This should work
on all RHEL 6 variants now.
