### PR TITLE
Fix SELinux Denials for Apache/Passenger

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -240,6 +240,9 @@ optional_policy(`
 
 tunable_policy(`httpd_run_foreman', `
     allow httpd_t passenger_tmp_t:sock_file write;
+    manage_files_pattern(httpd_t, foreman_log_t, foreman_log_t)
+    manage_dirs_pattern(httpd_t, foreman_var_run_t, foreman_var_run_t)
+    manage_files_pattern(httpd_t, foreman_var_run_t, forman_var_run_t)
 ')
 
 tunable_policy(`httpd_run_foreman', `


### PR DESCRIPTION
This fixes the following denieds I'm seeing on my production Foreman server configured by puppet:

```
allow httpd_t foreman_log_t:file { write open };
allow httpd_t foreman_var_run_t:dir { write rmdir read remove_name create add_name };
allow httpd_t foreman_var_run_t:file { rename setattr read create write ioctl unlink open append };
```
