### PR TITLE
fixes #17324 - set has_docker when container.if is found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ endif
 
 ifneq ("$(wildcard /usr/share/selinux/devel/include/*/docker.if)","")
 export M4PARAM += -D has_docker
-else
-ifneq ($(DISTRO),rhel6)
-$(error *** Interface docker.if not present, cannot continue ***)
-endif
+else ifneq ("$(wildcard /usr/share/selinux/devel/include/*/container.if)","")
+export M4PARAM += -D has_docker
+else ifneq ($(DISTRO),rhel6)
+$(error *** Interface container.if or docker.if not present, cannot continue ***)
 endif
 
 all: policies all-data


### PR DESCRIPTION
Builds correctly now ([f24](http://koji.katello.org/koji/taskinfo?taskID=562543), [el7](http://koji.katello.org/koji/taskinfo?taskID=562542)).