### PR TITLE
Fixes #18284 - Remove docker_port_t definition

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -396,9 +396,6 @@ read_files_pattern(websockify_t, puppet_var_lib_t, puppet_var_lib_t)
 # Docker
 #
 
-type docker_port_t;
-corenet_port(docker_port_t)
-
 tunable_policy(`passenger_can_connect_docker_tcp',`
     allow passenger_t docker_port_t:tcp_socket name_connect;
 ')


### PR DESCRIPTION
docker_port_t is defined on container-selinux. We could make
foreman-selinux depend on container-selinux to be able to install both
modules together on the same computer.

https://github.com/projectatomic/container-selinux/blob/master/container.te#L77 is where the type is defined