### PR TITLE
Fixes #9805 - fixed file_contexts: invalid context

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -265,6 +265,8 @@ optional_policy(`
         read_files_pattern(httpd_t, puppet_etc_t, puppet_etc_t)
         read_lnk_files_pattern(httpd_t, puppet_etc_t, puppet_etc_t)
         allow httpd_t puppet_port_t:tcp_socket name_connect;
+        # http://projects.theforeman.org/issues/9805
+        selinux_validate_context(passenger_t)
     ')
 ')
 


### PR DESCRIPTION
I was not able to reproduce but after multiple reports (see the associated
issue and bugzilla) and help from SELinux team of Red Hat we were able to
reveal a `dontaudit` missing rule that was causing this.