### PR TITLE
Fixes #18284 - removed docker_t port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 ifneq ("$(wildcard /usr/share/selinux/devel/include/*/docker.if)","")
 export M4PARAM += -D has_docker
 else ifneq ("$(wildcard /usr/share/selinux/devel/include/*/container.if)","")
-export M4PARAM += -D has_docker
+export M4PARAM += -D has_container
 else ifneq ($(DISTRO),rhel6)
 $(error *** Interface container.if or docker.if not present, cannot continue ***)
 endif

--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -8,8 +8,9 @@ for selinuxvariant in targeted
 do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
     # Remove all user defined ports (including the default one)
+    # (docker and elastic can be removed in future release)
     /usr/sbin/semanage port -E | \
-      grep -E '(docker|foreman_osapi_compute)_port_t' | \
+      grep -E '(elasticsearch|docker|foreman_osapi_compute)_port_t' | \
       sed s/-a/-d/g | \
       /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -21,13 +21,11 @@ do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
     /usr/sbin/semanage port -E > $TMP_PORTS
 
-    # Remove previously defined elasticsearch_port_t
+    # Remove previously defined docker_port_t
     # (this can be removed in future release)
-    grep elasticsearch_port_t $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
+    grep docker_port_t $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
 
     echo "boolean -m --on httpd_setrlimit" >> $TMP_EXEC_AFTER
-
-    grep -q docker_port_t $TMP_PORTS || echo "port -a -t docker_port_t -p tcp 2375-2376" >> $TMP_EXEC_AFTER
 
     if is_redhat_6; then
       grep -q foreman_osapi_compute_port_t $TMP_PORTS || \

--- a/foreman.te
+++ b/foreman.te
@@ -20,19 +20,6 @@ policy_module(foreman, @@VERSION@@)
 
 #######################################
 #
-# Definitions
-#
-# This defines set of special (unused) types which are used for easier detection
-# what definitions the policy was compiled with. Use seinfo -tTYPE to find
-# particular flag.
-#
-
-ifdef(`has_docker', `
-    type foreman_has_docker_defined_t;
-')
-
-#######################################
-#
 # Declarations
 #
 # Note: Some mod_passanger 4.0+ processes are running under httpd_t domain,
@@ -395,21 +382,18 @@ read_files_pattern(websockify_t, puppet_var_lib_t, puppet_var_lib_t)
 
 ######################################
 #
-# Docker
+# Container / Docker
 #
 
-type docker_port_t;
-corenet_port(docker_port_t)
-
-tunable_policy(`passenger_can_connect_docker_tcp',`
-    allow passenger_t docker_port_t:tcp_socket name_connect;
+optional_policy(`
+    tunable_policy(`passenger_can_connect_docker_tcp',`
+        container_stream_connect(passenger_t)
+    ')
 ')
 
 optional_policy(`
     tunable_policy(`passenger_can_connect_docker_unix',`
-        ifdef(`has_docker', `
-            docker_stream_connect(passenger_t)
-        ')
+        container_spc_stream_connect(passenger_t)
     ')
 ')
 


### PR DESCRIPTION
This replaces https://github.com/theforeman/foreman-selinux/pull/66

So the idea here is to remove docker from our policy. We will not use `has_docker` flag anymore, we do not support RHEL6 anymore so this is useless - it is present in RHEL7 and Fedora.