### PR TITLE
Refs #18284 - added foreman_container_port_t

### DIFF
--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -6,10 +6,6 @@ TMP_EXEC_AFTER=$(mktemp -t foreman-selinux-enable.XXXXX)
 TMP_PORTS=$(mktemp -t foreman-selinux-enable.XXXXX)
 trap "rm -rf '$TMP_EXEC_BEFORE' '$TMP_EXEC_AFTER' '$TMP_PORTS'" EXIT INT TERM
 
-is_redhat_6() {
-  [[ $(rpm -q --whatprovides redhat-release --qf '%{version}') == 6* ]]
-}
-
 # Load or upgrade foreman policy and set booleans.
 #
 # Dependant booleans must be managed in a separate transaction.
@@ -21,16 +17,16 @@ do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
     /usr/sbin/semanage port -E > $TMP_PORTS
 
-    # Remove previously defined docker_port_t
-    # (this can be removed in future release)
+    # Remove previously defined conflicting docker_port_t (this can be removed in future release)
     grep docker_port_t $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
 
-    echo "boolean -m --on httpd_setrlimit" >> $TMP_EXEC_AFTER
+    # Assign docker/container port only and only if it's undefined
+    grep -qE 'tcp 2375' $TMP_PORTS || \
+      echo "port -a -t foreman_container_port_t -p tcp 2375" >> $TMP_EXEC_AFTER
+    grep -qE 'tcp 2376' $TMP_PORTS || \
+      echo "port -a -t foreman_container_port_t -p tcp 2376" >> $TMP_EXEC_AFTER
 
-    if is_redhat_6; then
-      grep -q foreman_osapi_compute_port_t $TMP_PORTS || \
-        echo "port -a -t foreman_osapi_compute_port_t -p tcp 8774" >> $TMP_EXEC_AFTER
-    fi
+    echo "boolean -m --on httpd_setrlimit" >> $TMP_EXEC_AFTER
 
     # Execute port management commands and load policy
     test -s $TMP_EXEC_BEFORE && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_BEFORE

--- a/foreman.te
+++ b/foreman.te
@@ -64,17 +64,10 @@ gen_tunable(passenger_can_connect_all, false)
 
 ## <desc>
 ## <p>
-## Determine whether passenger can connect to Docker via TCP
-## </p>
-## </desc>
-gen_tunable(passenger_can_connect_docker_tcp, true)
-
-## <desc>
-## <p>
 ## Determine whether passenger can connect to Docker via local socket
 ## </p>
 ## </desc>
-gen_tunable(passenger_can_connect_docker_unix, true)
+gen_tunable(passenger_can_connect_container_unix, true)
 
 ## <desc>
 ## <p>
@@ -131,6 +124,9 @@ corenet_port(foreman_proxy_port_t)
 
 type foreman_osapi_compute_port_t;
 corenet_port(foreman_osapi_compute_port_t)
+
+type foreman_container_port_t;
+corenet_port(foreman_container_port_t)
 
 require{
     type bin_t;
@@ -385,23 +381,16 @@ read_files_pattern(websockify_t, puppet_var_lib_t, puppet_var_lib_t)
 # Container / Docker
 #
 
-optional_policy(`
-    tunable_policy(`passenger_can_connect_docker_tcp',`
-        ifdef(`has_container', `
-            container_stream_connect(passenger_t)
-        ')
-        ifdef(`has_docker', `
-            docker_stream_connect(passenger_t)
-        ')
-    ')
-')
+allow passenger_t foreman_container_port_t:tcp_socket name_connect;
 
 optional_policy(`
-    tunable_policy(`passenger_can_connect_docker_unix',`
+    tunable_policy(`passenger_can_connect_container_unix',`
         ifdef(`has_container', `
+            container_stream_connect(passenger_t)
             container_spc_stream_connect(passenger_t)
         ')
         ifdef(`has_docker', `
+            docker_stream_connect(passenger_t)
             #docker_spc_stream_connect(passenger_t)
             gen_require(`
                 type spc_t, spc_var_run_t;


### PR DESCRIPTION
During refactoring in the referenced ticket, I deleted `docker_port_t` type which was conflicting with container-selinux package. Unfortunately it turned out this port cannot be used to create allow rule for TCP connections, it is defined but there is no port number labeled with it.

This patch fixes this by introducing new type and assigning ports to it, but only whent they are not labeled yet. I assume the port assignements will be done in upstream and this will be rebased into RHEL later.

This patch also drops a legacy RHEL6 code from enable script and removes `foreman_can_connect_docker_tcp` boolean which is no longer relevant (we can always connect it as long as the port is assigned, unassign to disallow this). It also removes the other boolean from "docker" to "container" for the future.