### PR TITLE
Fixes #19053 - allow logrotate to send signals

### DIFF
--- a/foreman-proxy.te
+++ b/foreman-proxy.te
@@ -153,6 +153,12 @@ ifdef(`distro_rhel6', `
     miscfiles_read_generic_certs(foreman_proxy_t)
 ')
 
+# Logrotate in RHEL7 does not allow signals, RHBZ#1527522
+gen_require(`
+    type logrotate_t;
+')
+systemd_config_generic_services(logrotate_t)
+
 # generic support for plugins
 # executes sudo
 optional_policy(`

--- a/foreman.te
+++ b/foreman.te
@@ -231,6 +231,12 @@ miscfiles_manage_generic_cert_files(passenger_t)
 # /tmp/passenger-native-support-XXXXXX/passenger_native_support.so
 can_exec(passenger_t, passenger_tmp_t)
 
+# Logrotate in RHEL7 does not allow signals, RHBZ#1527522
+gen_require(`
+    type logrotate_t;
+')
+systemd_config_generic_services(logrotate_t)
+
 optional_policy(`
     tunable_policy(`passenger_run_foreman', `
         admin_pattern(httpd_t, foreman_lib_t, foreman_lib_t)


### PR DESCRIPTION
This is a temporary workaround to fix logrotate denials, multiple users reported this, both smart-proxy and smart-proxy dynflow core has the same issue. BZ that will fix this is RHEL 7.6 most likely, we need a solution today.

https://bugzilla.redhat.com/show_bug.cgi?id=1527522