### PR TITLE
Fixes #23127 - docker upgrade path is correct

### DIFF
--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -2,6 +2,7 @@
 set +e
 
 LIBEXEC_DIR=/usr/libexec/foreman-selinux
+LOG=/var/log/foreman-selinux-install.log
 
 # Run hooks
 find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
@@ -12,11 +13,15 @@ find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bi
 for selinuxvariant in targeted
 do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
+    # Create log entry
+    echo "$(date) $0" >> $LOG
+
     # Remove all user defined ports (including the default one)
     # (docker and elastic can be removed in future release)
     /usr/sbin/semanage port -E | \
       grep -E '(elasticsearch|docker|foreman_.*)_port_t' | \
       sed s/-a/-d/g | \
+      tee -a $LOG | \
       /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy
     /usr/sbin/semodule -s $selinuxvariant -r foreman

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -4,6 +4,7 @@ set +e
 TMP_EXEC_BEFORE=$(mktemp -t foreman-selinux-enable.XXXXX)
 TMP_EXEC_AFTER=$(mktemp -t foreman-selinux-enable.XXXXX)
 TMP_PORTS=$(mktemp -t foreman-selinux-enable.XXXXX)
+LOG=/var/log/foreman-selinux-install.log
 trap "rm -rf '$TMP_EXEC_BEFORE' '$TMP_EXEC_AFTER' '$TMP_PORTS'" EXIT INT TERM
 LIBEXEC_DIR=/usr/libexec/foreman-selinux
 
@@ -19,10 +20,20 @@ find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bi
 for selinuxvariant in targeted
 do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
+    # Create port list cache
     /usr/sbin/semanage port -E > $TMP_PORTS
 
     # Remove previously defined conflicting docker_port_t (this can be removed in future release)
-    grep docker_port_t $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
+    grep -E '(container|docker)_port_t' $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
+
+    # Commit changes
+    test -s $TMP_EXEC_BEFORE && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_BEFORE
+
+    # Load new policy
+    /usr/sbin/semanage module -S $selinuxvariant -a /usr/share/selinux/${selinuxvariant}/foreman.pp.bz2
+
+    # Create port list cache
+    /usr/sbin/semanage port -E > $TMP_PORTS
 
     # Assign docker/container port only and only if it's undefined
     grep -qE 'tcp 2375' $TMP_PORTS || \
@@ -30,12 +41,16 @@ do
     grep -qE 'tcp 2376' $TMP_PORTS || \
       echo "port -a -t foreman_container_port_t -p tcp 2376" >> $TMP_EXEC_AFTER
 
+    # Set flags for passenger
     echo "boolean -m --on httpd_setrlimit" >> $TMP_EXEC_AFTER
 
-    # Execute port management commands and load policy
-    test -s $TMP_EXEC_BEFORE && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_BEFORE
-    /usr/sbin/semanage module -S $selinuxvariant -a /usr/share/selinux/${selinuxvariant}/foreman.pp.bz2
+    # Commit changes
     test -s $TMP_EXEC_AFTER && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_AFTER
+
+    # Append to log file
+    echo "$(date) $0" >> $LOG
+    cat $TMP_EXEC_BEFORE >> $LOG
+    cat $TMP_EXEC_AFTER >> $LOG
   fi
 done
 


### PR DESCRIPTION
Upgrade patch was not clean for docker, we were not calling "semanage port -E" after policy was loaded, therefore the after commands could not be scheduled correctly. See the issue for more info.

This fixes it, basically it calls port list twice. It also makes sure that `container_port_t` which could possibly occupy the port range is also removed prior assigning the ports to our own type. In addition to that, it creates a log file which contains information about semanage actions taken by enable/disable scripts:

```
Thu Apr  5 08:25:39 EDT 2018 foreman-selinux-enable
port -d -t container_port_t -p tcp 2375-2376
port -a -t foreman_container_port_t -p tcp 2375
port -a -t foreman_container_port_t -p tcp 2376
boolean -m --on httpd_setrlimit

```