### PR TITLE
Fixes #23134 - support for plugin hooks

### DIFF
--- a/foreman-proxy-selinux-relabel
+++ b/foreman-proxy-selinux-relabel
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+LIBEXEC_DIR=/usr/libexec/foreman-selinux
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-before-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
+
 /sbin/restorecon -ri $* \
   /usr/share/foreman-proxy/bin/smart-proxy \
   /etc/foreman-proxy \
@@ -7,5 +12,8 @@
   /var/lib/foreman-proxy \
   /var/log/foreman-proxy \
   /var/run/foreman-proxy
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-after-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
 
 exit 0

--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -1,6 +1,11 @@
 #!/bin/bash
 set +e
 
+LIBEXEC_DIR=/usr/libexec/foreman-selinux
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+
 # Unload foreman policy and set booleans. Dependant booleans must be managed in
 # a separate transaction. Do not forget to edit countepart file
 # (enable/disable) when updating this script.
@@ -17,3 +22,8 @@ do
     /usr/sbin/semodule -s $selinuxvariant -r foreman
   fi
 done
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-after-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+
+exit 0

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -5,6 +5,10 @@ TMP_EXEC_BEFORE=$(mktemp -t foreman-selinux-enable.XXXXX)
 TMP_EXEC_AFTER=$(mktemp -t foreman-selinux-enable.XXXXX)
 TMP_PORTS=$(mktemp -t foreman-selinux-enable.XXXXX)
 trap "rm -rf '$TMP_EXEC_BEFORE' '$TMP_EXEC_AFTER' '$TMP_PORTS'" EXIT INT TERM
+LIBEXEC_DIR=/usr/libexec/foreman-selinux
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
 
 # Load or upgrade foreman policy and set booleans.
 #
@@ -34,3 +38,8 @@ do
     test -s $TMP_EXEC_AFTER && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_AFTER
   fi
 done
+
+# Run hooks
+find ${LIBEXEC_DIR} -name \*-after-enable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+
+exit 0


### PR DESCRIPTION
We need to allow to katello-selinux to hook onto foreman-selinux-enable (disable, relabel) scripts easily.

This can be done via /usr/libexec/foreman-selinux/enable.d/*.after.sh (and before.sh) scripts executed before or after scripts.

Packaging PR will follow once this is merged to get that directory created.