### PR TITLE
Fixes #23619 - disable script removes foreman ports

### DIFF
--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -10,7 +10,7 @@ do
     # Remove all user defined ports (including the default one)
     # (docker and elastic can be removed in future release)
     /usr/sbin/semanage port -E | \
-      grep -E '(elasticsearch|docker|foreman_osapi_compute)_port_t' | \
+      grep -E '(elasticsearch|docker|foreman_.*)_port_t' | \
       sed s/-a/-d/g | \
       /usr/sbin/semanage -S $selinuxvariant -i -
     # Unload policy


### PR DESCRIPTION
The disable script was not removing all definition, it now catches all "foreman_*_port_t" ports properly. This made reload of policy impossible.