### PR TITLE
Fixes #24952 - Check if the directory exists before executing

### DIFF
--- a/foreman-proxy-selinux-relabel
+++ b/foreman-proxy-selinux-relabel
@@ -3,7 +3,9 @@
 LIBEXEC_DIR=/usr/libexec/foreman-selinux
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-before-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-before-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 /sbin/restorecon -ri $* \
   /usr/share/foreman-proxy/bin/smart-proxy \
@@ -14,6 +16,8 @@ find ${LIBEXEC_DIR} -name \*-before-relabel.sh -type f -executable -exec /usr/bi
   /var/run/foreman-proxy
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-after-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-after-relabel.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 exit 0

--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -5,7 +5,9 @@ LIBEXEC_DIR=/usr/libexec/foreman-selinux
 LOG=/var/log/foreman-selinux-install.log
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 # Unload foreman policy and set booleans. Dependant booleans must be managed in
 # a separate transaction. Do not forget to edit countepart file
@@ -29,6 +31,8 @@ do
 done
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-after-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-after-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 exit 0

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -9,7 +9,9 @@ trap "rm -rf '$TMP_EXEC_BEFORE' '$TMP_EXEC_AFTER' '$TMP_PORTS'" EXIT INT TERM
 LIBEXEC_DIR=/usr/libexec/foreman-selinux
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 # Load or upgrade foreman policy and set booleans.
 #
@@ -55,6 +57,8 @@ do
 done
 
 # Run hooks
-find ${LIBEXEC_DIR} -name \*-after-enable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+if [[ -d $LIBEXEC_DIR ]] ; then
+	find ${LIBEXEC_DIR} -name \*-after-enable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+fi
 
 exit 0


### PR DESCRIPTION
Otherwise you get warnings:

    find: '/usr/libexec/foreman-selinux': No such file or directory