### PR TITLE
Fixes #16273 - allow execmem

### DIFF
--- a/foreman-proxy.te
+++ b/foreman-proxy.te
@@ -104,6 +104,9 @@ files_spool_filetrans(foreman_proxy_t, foreman_proxy_spool_t, { dir file })
 # starting via /bin/env
 corecmd_read_bin_symlinks(foreman_proxy_t)
 
+# FFI library callbacks - see RM#26520 for more info
+allow foreman_proxy_t self:process execmem;
+
 # ruby runtime
 corecmd_search_bin(foreman_proxy_t)
 corecmd_exec_bin(foreman_proxy_t)


### PR DESCRIPTION
FFI library callback feature executes mapped memory of temporary files. This
sounds dangerous, however FFI authors do not think this is a problem, they did
not find a workaround in the FFI code as a good option and they recommend to
allow this in SELinux in the official documentation:

* https://bitbucket.org/cffi/cffi/issues/231
* https://cffi.readthedocs.io/en/latest/using.html#callbacks

This patch enables execmem both for passenger and smart proxy process as there
is no other good solution to this problem.