### PR TITLE
Fixes #26762 - move auth_read_passwd ouside the tunable_policy

### DIFF
--- a/foreman-proxy.te
+++ b/foreman-proxy.te
@@ -247,6 +247,9 @@ tunable_policy(`foreman_proxy_manage_dns_nsupdate', `
 ')
 
 # DHCP PLUGIN
+ifndef(`distro_rhel6', `
+    auth_read_passwd(foreman_proxy_t)
+')
 tunable_policy(`foreman_proxy_manage_dhcp_generic', `
     # ping support via ECHO TCP service
     ifdef(`distro_rhel6', `
@@ -255,9 +258,6 @@ tunable_policy(`foreman_proxy_manage_dhcp_generic', `
         corenet_tcp_connect_echo_port(foreman_proxy_t)
     ')
     # ping support via ICMP /usr/bin/ping (it has suid)
-    ifndef(`distro_rhel6', `
-        auth_read_passwd(foreman_proxy_t)
-    ')
     netutils_domtrans_ping(foreman_proxy_t)
 ')
 


### PR DESCRIPTION
auth_read_passwd in EL8 (and modern Fedora) includes an optional
statement, which cannot be inside a tunable policy.
This moves it outside the tunable, making it always enabled. Not
optimal, but it makes the policy work across all distros.