### PR TITLE
Fixes #26948 - added dac_override capability back

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -173,6 +173,8 @@ require{
 # Passanger/httpd local policy
 #
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1716944
+allow passenger_t self:capability dac_override;
 allow passenger_t self:capability sys_resource;
 allow passenger_t self:process signull;
 allow passenger_t self:tcp_socket listen;


### PR DESCRIPTION
It was removed in core policy for some reason but Foreman will not start on RHEL8 without this in passenger.