### PR TITLE
Fixes #26951 - allow execmem in passenger too

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -177,6 +177,9 @@ allow passenger_t self:capability sys_resource;
 allow passenger_t self:process signull;
 allow passenger_t self:tcp_socket listen;
 
+# rubygem FFI is used in foreman-tasks (BZ#1670109 / RM#26951)
+allow passenger_t self:process execmem;
+
 miscfiles_read_localization(passenger_t)
 
 # Allow Foreman to connect to Foreman Proxy on port 9090 (Katello)


### PR DESCRIPTION
We had this rule, then we removed it but it's back. Let's add it back.

Similar issue was: https://github.com/theforeman/foreman-selinux/pull/88