### PR TITLE
Fixes #29115 - policy for foreman-cockpit service

### DIFF
--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -37,11 +37,14 @@ do
     # Create port list cache
     /usr/sbin/semanage port -E > $TMP_PORTS
 
-    # Assign docker/container port only and only if it's undefined
+    # Assign foreman custom ports
     grep -qE 'tcp 2375' $TMP_PORTS || \
       echo "port -a -t foreman_container_port_t -p tcp 2375" >> $TMP_EXEC_AFTER
     grep -qE 'tcp 2376' $TMP_PORTS || \
       echo "port -a -t foreman_container_port_t -p tcp 2376" >> $TMP_EXEC_AFTER
+    # Assign base policy ports
+    grep -qE 'tcp 19090' $TMP_PORTS || \
+      echo "port -a -t websm_port_t -p tcp 19090" >> $TMP_EXEC_AFTER
 
     # Set flags for passenger
     echo "boolean -m --on httpd_setrlimit" >> $TMP_EXEC_AFTER

--- a/foreman.te
+++ b/foreman.te
@@ -185,6 +185,7 @@ allow passenger_t self:process execmem;
 miscfiles_read_localization(passenger_t)
 
 # Allow Foreman to connect to Foreman Proxy on port 9090 (Katello)
+# or to connect to Foreman Cockpit on port 19090 (Remote Execution)
 allow passenger_t websm_port_t:tcp_socket name_connect;
 
 # Allow Foreman to connect to Foreman Proxy on a defined port


### PR DESCRIPTION
Policy for Foreman Cockpit integration. Foreman connects to Cockpit running on custom port 19090 (launched via foreman-cockpit.service provided by Remote Execution) for authorization. Port 9090 could not be used as it's in used by Smart Proxy.

This works be using existing `websm_port_t` which is used by Cockpit in base policy and assigning the free port number 19090 to it. The passenger domain already has a rule to connect to websm port (9090) because that's what Smart Proxy uses, so I only left a comment there.

https://github.com/theforeman/foreman_remote_execution/pull/441/files