### PR TITLE
Fixes #28252 - rules for foreman cockpit session

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -19,6 +19,7 @@
   /usr/share/passenger/helper-scripts \
   /usr/lib{64,}/passenger/support-binaries \
   /usr/lib{64,}exec/passenger \
+  /usr/sbin/foreman-cockpit-session \
   /var/run/rubygem-passenger
 
 # relabel SCL mod_passenger and foreman plugins if SCL is found

--- a/foreman.fc
+++ b/foreman.fc
@@ -51,6 +51,11 @@
 /usr/share/gems/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
 /usr/lib6?4?/gems/(exts|ruby)/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
+# Foreman Remote Execution
+
+/usr/sbin/foreman-cockpit-session       gen_context(system_u:object_r:cockpit_session_exec_t,s0)
+/usr/share/gems/gems/foreman_remote_execution-.*/extra/cockpit/foreman-cockpit-session -- gen_context(system_u:object_r:cockpit_session_exec_t,s0)
+
 # Foreman Hooks plugin
 
 /usr/share/foreman/config/hooks(/.*)?   gen_context(system_u:object_r:foreman_hook_t,s0)

--- a/foreman.te
+++ b/foreman.te
@@ -166,6 +166,9 @@ require{
     type puppetmaster_t;
     type sysctl_net_t;
     type websm_port_t;
+    type cockpit_ws_t;
+    type cockpit_session_t;
+    type cockpit_session_exec_t;
 }
 
 #######################################
@@ -185,7 +188,7 @@ allow passenger_t self:process execmem;
 miscfiles_read_localization(passenger_t)
 
 # Allow Foreman to connect to Foreman Proxy on port 9090 (Katello)
-# or to connect to Foreman Cockpit on port 19090 (Remote Execution)
+# or to connect to remote Cockpit instance (via Remote Execution)
 allow passenger_t websm_port_t:tcp_socket name_connect;
 
 # Allow Foreman to connect to Foreman Proxy on a defined port
@@ -349,6 +352,24 @@ optional_policy(`
         corenet_tcp_connect_ldap_port(passenger_t)
     ')
 ')
+
+#######################################
+#
+# Remote Execution
+#
+
+# File /usr/sbin/foreman-cockpit-session is a symlink
+read_lnk_files_pattern(cockpit_ws_t, cockpit_session_exec_t, cockpit_session_exec_t)
+read_lnk_files_pattern(cockpit_session_t, cockpit_session_exec_t, cockpit_session_exec_t)
+
+# Run /usr/bin/env and /usr/bin/ruby
+corecmd_exec_bin(cockpit_ws_t)
+
+# Connect to Foreman HTTP(s) port
+corenet_tcp_connect_http_port(cockpit_session_t)
+
+# Connect to remote Cockpit instance HTTP(s) port
+corenet_tcp_connect_websm_port(cockpit_session_t)
 
 #######################################
 #


### PR DESCRIPTION
Fixes a denial when switching from Foreman to Cockpit. Tested with Satellite 6.7 snap 2, however this should work with Foreman 1.24 too.

https://bugzilla.redhat.com/show_bug.cgi?id=1770999#c4