### PR TITLE
Refs #28252 - allow httpd_t to connect to cockpit session

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -368,8 +368,11 @@ corecmd_exec_bin(cockpit_ws_t)
 # Connect to Foreman HTTP(s) port
 corenet_tcp_connect_http_port(cockpit_session_t)
 
-# Connect to remote Cockpit instance HTTP(s) port
+# Connect to remote Cockpit instance HTTPS port
 corenet_tcp_connect_websm_port(cockpit_session_t)
+
+# Connect to Foreman Cockpit instance HTTPS port
+corenet_tcp_connect_websm_port(httpd_t)
 
 #######################################
 #


### PR DESCRIPTION
Forgot this one, httpd connects to foreman-cockpit and then foreman connects to remote cockpit.