### PR TITLE
make /run/foreman.sock match ALL files, not only regular

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -30,7 +30,7 @@
 /var/log/foreman(/.*)?                              gen_context(system_u:object_r:foreman_log_t,s0)
 
 /var/run/foreman(/.*)?                              gen_context(system_u:object_r:foreman_var_run_t,s0)
-/run/foreman\.sock                              --  gen_context(system_u:object_r:foreman_var_run_t,s0)
+/run/foreman\.sock                                  gen_context(system_u:object_r:foreman_var_run_t,s0)
 
 /usr/share/foreman/.ssh(/.*)?                       gen_context(system_u:object_r:ssh_home_t,s0)
 /usr/share/foreman/extras/noVNC/websockify\.py      gen_context(system_u:object_r:websockify_exec_t,s0)


### PR DESCRIPTION
a socket is not a regular file, and thus this rule did not match on
(at least) EL8.