### PR TITLE
match /var/run, not /run

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -30,7 +30,7 @@
 /var/log/foreman(/.*)?                              gen_context(system_u:object_r:foreman_log_t,s0)
 
 /var/run/foreman(/.*)?                              gen_context(system_u:object_r:foreman_var_run_t,s0)
-/run/foreman\.sock                                  gen_context(system_u:object_r:foreman_var_run_t,s0)
+/var/run/foreman\.sock                              gen_context(system_u:object_r:foreman_var_run_t,s0)
 
 /usr/share/foreman/.ssh(/.*)?                       gen_context(system_u:object_r:ssh_home_t,s0)
 /usr/share/foreman/extras/noVNC/websockify\.py      gen_context(system_u:object_r:websockify_exec_t,s0)


### PR DESCRIPTION
/run is an alias for /var/run, so creating rules for /run doesn't work:

    # semanage fcontext --add -t foreman_var_run_t /run/foreman.sock
    ValueError: File spec /run/foreman.sock conflicts with equivalency rule '/run /var/run'; Try adding '/var/run/foreman.sock' instead