### PR TITLE
Fixes #31922 - Don't audit denials for rpm_script_tmp_t

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -327,6 +327,21 @@ tunable_policy(`foreman_rails_can_connect_all',`
 rpm_exec(foreman_rails_t)
 rpm_read_db(foreman_rails_t)
 
+# Disregard denials for CVE-2019-3881 where bundler creates files in
+# /tmp/bundler if the home is not writable
+# This needs to be done for any type which can create /tmp/bundler
+gen_require(`
+    type rpm_script_tmp_t;
+    type system_cronjob_tmp_t;
+')
+
+dontaudit foreman_rails_t rpm_script_tmp_t:dir manage_dir_perms;
+dontaudit foreman_rails_t rpm_script_tmp_t:dir rw_dir_perms;
+dontaudit foreman_rails_t rpm_script_tmp_t:file manage_file_perms;
+dontaudit foreman_rails_t system_cronjob_tmp_t:dir manage_dir_perms;
+dontaudit foreman_rails_t system_cronjob_tmp_t:dir rw_dir_perms;
+dontaudit foreman_rails_t system_cronjob_tmp_t:file manage_file_perms;
+
 ######################################
 #
 # Logrotate and cron
@@ -334,7 +349,6 @@ rpm_read_db(foreman_rails_t)
 
 gen_require(`
     type logrotate_t;
-    type system_cronjob_tmp_t;
 ')
 
 # Allow sending signals in logrotate scripts
@@ -346,12 +360,6 @@ allow logrotate_t foreman_rails_unit_file_t:service manage_service_perms;
 # /etc/logrotate.d/foreman-proxy with logs as var_log_t
 files_list_var(logrotate_t)
 systemd_config_generic_services(logrotate_t)
-
-# When Foreman cronjob is started before Ruby on Rails, /tmp/bundler
-# is created with system_u:object_r:system_cronjob_tmp_t:s0 label denying
-# access to the web process
-manage_files_pattern(foreman_rails_t, system_cronjob_tmp_t, system_cronjob_tmp_t)
-manage_dirs_pattern(foreman_rails_t, system_cronjob_tmp_t, system_cronjob_tmp_t)
 
 #######################################
 #


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1651826 is the root cause for this. It was closed as WONTFIX for rh-ruby25 and RHEL8 so we'll likely see these for a while.

Having AVCs in audit logging that are "normal" means you can't easily distinguish real and "accepted". These AVCs should not be logged.

In fc3eb992a285bc701e8327815c43761a094b2a67 there was already a workaround for this but in the cron context. This commit removes those and changes it to the same dontaudit statements as for rpm_script_tmp_t.

This is an untested alternative to https://github.com/theforeman/foreman-selinux/pull/121.