### PR TITLE
Fixes #31993 - add OpenStack documented ports

### DIFF
--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -10,7 +10,7 @@ LIBEXEC_DIR=/usr/libexec/foreman-selinux
 
 # Run hooks
 if [[ -d $LIBEXEC_DIR ]] ; then
-	find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+  find ${LIBEXEC_DIR} -name \*-before-disable.sh -type f -executable -exec /usr/bin/bash '{}' \;
 fi
 
 # Load or upgrade foreman policy and set booleans.
@@ -37,11 +37,19 @@ do
     # Create port list cache
     /usr/sbin/semanage port -E > $TMP_PORTS
 
-    # Assign foreman custom ports
-    grep -qE 'tcp 2375' $TMP_PORTS || \
-      echo "port -a -t foreman_container_port_t -p tcp 2375" >> $TMP_EXEC_AFTER
-    grep -qE 'tcp 2376' $TMP_PORTS || \
-      echo "port -a -t foreman_container_port_t -p tcp 2376" >> $TMP_EXEC_AFTER
+    # Assign foreman custom ports - container
+    for PORT in 2375 2376; do
+      grep -qE "tcp $PORT\$" $TMP_PORTS || \
+        echo "port -a -t foreman_container_port_t -p tcp $PORT" >> $TMP_EXEC_AFTER
+    done
+
+    # Assign foreman custom ports - openstack
+    for PORT in 9000 13000 13004 13041 13042 13050 13080 13292 13311 13385 13386 \
+      13696 13774 13776 13778 13786 13788 13808 13876 13888 13977 13989; do
+      grep -qE "tcp $PORT\$" $TMP_PORTS || \
+        echo "port -a -t foreman_openstack_port_t -p tcp $PORT" >> $TMP_EXEC_AFTER
+    done
+
     # Assign base policy ports
     grep -qE 'tcp 19090' $TMP_PORTS || \
       echo "port -a -t websm_port_t -p tcp 19090" >> $TMP_EXEC_AFTER
@@ -61,7 +69,7 @@ done
 
 # Run hooks
 if [[ -d $LIBEXEC_DIR ]] ; then
-	find ${LIBEXEC_DIR} -name \*-after-enable.sh -type f -executable -exec /usr/bin/bash '{}' \;
+  find ${LIBEXEC_DIR} -name \*-after-enable.sh -type f -executable -exec /usr/bin/bash '{}' \;
 fi
 
 exit 0

--- a/foreman.te
+++ b/foreman.te
@@ -148,6 +148,9 @@ corenet_port(foreman_osapi_compute_port_t)
 type foreman_container_port_t;
 corenet_port(foreman_container_port_t)
 
+type foreman_openstack_port_t;
+corenet_port(foreman_openstack_port_t)
+
 require{
     type bin_t;
     type httpd_t;
@@ -384,12 +387,14 @@ corenet_tcp_connect_websm_port(httpd_t)
 #
 
 tunable_policy(`foreman_rails_can_connect_openstack',`
-    # keystone (identity service)
+    # base policy: keystone (identity service)
     corenet_tcp_connect_commplex_main_port(foreman_rails_t)
-    # nova (compute service)
+    # base policy: nova (compute service)
     corenet_tcp_connect_osapi_compute_port(foreman_rails_t)
-    # neutron (network service)
+    # base policy: neutron (network service)
     corenet_tcp_connect_neutron_port(foreman_rails_t)
+    # foreman policy: ports from OpenStack documentation
+    allow foreman_rails_t foreman_openstack_port_t:tcp_socket name_connect;
 ')
 
 #######################################


### PR DESCRIPTION
Foreman can connect to OpenStack, however the API is fairly complicated with lots of endpoints and introspection. We have been adding ports on a "when it fails" basis but to improve experience, I would like to propose adding rules for all ports which are documented as a public API in OpenStack: https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/firewall_rules_for_red_hat_openstack_platform/firewall_rules_for_red_hat_openstack_platform

See the RM issue for the grep command which reveals all those ports.

Also upstream OpenStack defines the following ports (some of them are covered by the base policy rules we already have) so I wonder - should we add the rest too: https://docs.openstack.org/install-guide/firewalls-default-ports.html