### PR TITLE
Refs #32022 - Remove Ruby 1.8 paths

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -16,9 +16,7 @@
   /etc/logrotate.d/foreman* \
   /etc/cron.d/foreman* \
   /usr/libexec/foreman \
-  /usr/lib{64,}/ruby/gems/1.8/gems/passenger-* \
   /usr/lib{64,}/gems/ruby/passenger-*/agents \
-  /usr/lib{64,}/ruby/site_ruby/1.8/x86_64-linux/agents \
   /usr/share/passenger/helper-scripts \
   /usr/lib{64,}/passenger/support-binaries \
   /usr/lib{64,}exec/passenger \

--- a/foreman.fc
+++ b/foreman.fc
@@ -40,11 +40,8 @@
 
 # Passenger non-SCL file contexts
 
-/usr/lib/ruby/gems/1.8/gems/passenger-.*/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
-/usr/lib6?4?/ruby/site_ruby/1.8/x86_64-linux/agents/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 /usr/libexec/passenger/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
-/usr/lib/ruby/gems/1.8/gems/passenger-.*/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
 /usr/share/passenger/helper-scripts/prespawn -- gen_context(system_u:object_r:passenger_exec_t,s0)
 
 /usr/lib6?4?/passenger/support-binaries/.* -- gen_context(system_u:object_r:passenger_exec_t,s0)


### PR DESCRIPTION
This removes the Ruby 1.8 paths as file contexts. EL6 shipped with Ruby 1.8 but that was dropped a long time ago. That means these files never show up anymore.

The issue isn't really resolved with it since restorecon still complains about missing files, but this reduces the output.