### PR TITLE
Remove unused foreman_rails_can_connect_http tunable

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -75,13 +75,6 @@ gen_tunable(foreman_rails_can_spawn_ssh, true)
 
 ## <desc>
 ## <p>
-## Determine whether Ruby on Rails can connect to http_port_t when preloading app.
-## </p>
-## </desc>
-gen_tunable(foreman_rails_can_connect_http, true)
-
-## <desc>
-## <p>
 ## Determine whether Ruby on Rails can connect to http_cache_port_t and squid_port_t.
 ## </p>
 ## </desc>


### PR DESCRIPTION
Since 3087a3f799d112211c9eae35b2fe92a3e718621f this is unused.