### PR TITLE
Replace CentOS Linux 8 in CI with CentOS Stream 8

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         centos: ["7", "8"]
     container:
-      image: centos:${{ matrix.centos }}
+      image: quay.io/centos/centos:${{ matrix.centos }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos: ["7", "8"]
+        centos: ["7", "stream8"]
     container:
       image: quay.io/centos/centos:${{ matrix.centos }}
 
@@ -21,8 +21,12 @@ jobs:
       - name: Install SELinux
         run: yum install -y selinux-policy-devel policycoreutils bzip2 perl
 
+      - name: Install container-selinux
+        run: dnf install -y container-selinux
+        if: matrix.centos == 'stream8'
+
       - name: Compile policy
-        run: make DISTRO=rhel${{ matrix.centos }}
+        run: make DISTRO=rhel$(rpm --eval '%rhel')
 
       - name: Check syntax of shell scripts
         run: bash -n *-relabel *-enable *-disable


### PR DESCRIPTION
foreman_docker is no longer a thing. This PR escalated from a fix to test with Stream 8 but in doing so I found more. See individual commits for details.