### PR TITLE
Fixes #34730 - Drop docker/container integration

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -24,10 +24,6 @@ jobs:
       - name: Install SELinux
         run: yum install -y selinux-policy-devel policycoreutils bzip2 perl
 
-      - name: Install container-selinux
-        run: dnf install -y container-selinux
-        if: matrix.centos == 'stream8'
-
       - name: Compile policy
         run: make DISTRO=rhel$(rpm --eval '%rhel')
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@ ifndef DISTRO
 $(error *** Set the DISTRO variable e.g. rhel7 or fedora21 ***)
 endif
 
-ifneq ("$(wildcard /usr/share/selinux/devel/include/*/docker.if)","")
-export M4PARAM += -D has_docker
-else ifneq ("$(wildcard /usr/share/selinux/devel/include/*/container.if)","")
-export M4PARAM += -D has_container
-else ifneq ($(DISTRO),rhel6)
-$(error *** Interface container.if or docker.if not present, cannot continue ***)
-endif
-
 all: policies all-data
 
 load: \

--- a/foreman-selinux-disable
+++ b/foreman-selinux-disable
@@ -19,9 +19,8 @@ do
     echo "$(date) $0" >> $LOG
 
     # Remove all user defined ports (including the default one)
-    # (docker and elastic can be removed in future release)
     /usr/sbin/semanage port -E | \
-      grep -E '(elasticsearch|docker|foreman_.*)_port_t' | \
+      grep 'foreman_proxy_port_t' | \
       sed s/-a/-d/g | \
       tee -a $LOG | \
       /usr/sbin/semanage -S $selinuxvariant -i -

--- a/foreman-selinux-enable
+++ b/foreman-selinux-enable
@@ -22,26 +22,12 @@ fi
 for selinuxvariant in targeted
 do
   if /usr/sbin/semodule -s $selinuxvariant -l >/dev/null; then
-    # Create port list cache
-    /usr/sbin/semanage port -E > $TMP_PORTS
-
-    # Remove previously defined conflicting docker_port_t (this can be removed in future release)
-    grep -E '(container|docker)_port_t' $TMP_PORTS | sed s/-a/-d/g >> $TMP_EXEC_BEFORE
-
-    # Commit changes
-    test -s $TMP_EXEC_BEFORE && /usr/sbin/semanage -S $selinuxvariant -i $TMP_EXEC_BEFORE
-
     # Load new policy
     /usr/sbin/semanage module -S $selinuxvariant -a /usr/share/selinux/${selinuxvariant}/foreman.pp.bz2
 
     # Create port list cache
     /usr/sbin/semanage port -E > $TMP_PORTS
 
-    # Assign foreman custom ports
-    grep -qE 'tcp 2375' $TMP_PORTS || \
-      echo "port -a -t foreman_container_port_t -p tcp 2375" >> $TMP_EXEC_AFTER
-    grep -qE 'tcp 2376' $TMP_PORTS || \
-      echo "port -a -t foreman_container_port_t -p tcp 2376" >> $TMP_EXEC_AFTER
     # Assign base policy ports
     grep -qE 'tcp 19090' $TMP_PORTS || \
       echo "port -a -t websm_port_t -p tcp 19090" >> $TMP_EXEC_AFTER

--- a/foreman.te
+++ b/foreman.te
@@ -54,13 +54,6 @@ gen_tunable(websockify_can_connect_all, false)
 
 ## <desc>
 ## <p>
-## Determine whether Ruby on Rails can connect to Docker via local socket
-## </p>
-## </desc>
-gen_tunable(foreman_rails_can_connect_container_unix, true)
-
-## <desc>
-## <p>
 ## Determine whether Ruby on Rails can connect to OpenStack
 ## </p>
 ## </desc>
@@ -130,9 +123,6 @@ corenet_port(foreman_proxy_port_t)
 
 type foreman_osapi_compute_port_t;
 corenet_port(foreman_osapi_compute_port_t)
-
-type foreman_container_port_t;
-corenet_port(foreman_container_port_t)
 
 require{
     type bin_t;
@@ -450,33 +440,6 @@ corecmd_exec_ls(websockify_t)
 
 tunable_policy(`websockify_can_connect_all',`
     corenet_tcp_connect_all_ports(websockify_t)
-')
-
-######################################
-#
-# Container / Docker
-#
-
-allow foreman_rails_t foreman_container_port_t:tcp_socket name_connect;
-
-optional_policy(`
-    tunable_policy(`foreman_rails_can_connect_container_unix',`
-        ifdef(`has_container', `
-            container_stream_connect(foreman_rails_t)
-            container_spc_stream_connect(foreman_rails_t)
-        ')
-        ifdef(`has_docker', `
-            docker_stream_connect(foreman_rails_t)
-            #docker_spc_stream_connect(foreman_rails_t)
-            gen_require(`
-                type spc_t, spc_var_run_t;
-                attribute pidfile;
-            ')
-            files_search_pids(foreman_rails_t)
-            allow foreman_rails_t pidfile:sock_file write_sock_file_perms;
-            allow foreman_rails_t spc_t:unix_stream_socket connectto;
-        ')
-    ')
 ')
 
 ######################################

--- a/foreman.te
+++ b/foreman.te
@@ -127,13 +127,6 @@ corenet_port(foreman_osapi_compute_port_t)
 require{
     type bin_t;
     type httpd_t;
-    type httpd_tmp_t;
-    type ifconfig_exec_t;
-    type init_t;
-    type proc_net_t;
-    type puppetmaster_exec_t;
-    type puppetmaster_t;
-    type sysctl_net_t;
     type websm_port_t;
     type cockpit_ws_t;
     type cockpit_session_t;


### PR DESCRIPTION
This used to be needed for foreman_docker but that has been dropped a while back. This means it can be removed from the policy.

It also drops some leftover type definitions.