### PR TITLE
Fixes #34807 - Compatibility with systemd-resolved

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -245,6 +245,9 @@ corenet_udp_bind_generic_node(foreman_rails_t)
 # The following macro incudes corenet_tcp_connect_dns_port(foreman_rails_t)
 sysnet_dns_name_resolve(foreman_rails_t)
 
+# Allow reading /etc/resolv.conf when using systemd-resolved
+allow foreman_rails_t net_conf_t:lnk_file read;
+
 # rubygem FFI is used in foreman-tasks (BZ#1670109 / RM#26951)
 allow foreman_rails_t self:process execmem;
 


### PR DESCRIPTION
When using systemd-resolved the file `/etc/resolv.conf` is labeled as `net_conf_t`. At least on EL7 this gave denials and resulted in not being allowed to perform any name resolution, which is needed to connect to Foreman Proxies and other external services.

Looking in Rawhide's SELinux policy for net_conf_t suggests it doesn't really contain secret files:

```console
$ rg net_conf_t
policy/modules/system/sysnetwork.te
52:type net_conf_t alias resolv_conf_t;
53:files_config_file(net_conf_t)
56:	init_daemon_run_dir(net_conf_t, "network")
98:# in /etc created by dhcpcd will be labelled net_conf_t.
99:allow dhcpc_t net_conf_t:file manage_file_perms;
100:allow dhcpc_t net_conf_t:file relabel_file_perms;
102:files_etc_filetrans(dhcpc_t, net_conf_t, file)

policy/modules/system/sysnetwork.fc
11:/dev/shm/network(/.*)?		gen_context(system_u:object_r:net_conf_t,s0)
22:/etc/ethers		--	gen_context(system_u:object_r:net_conf_t,s0)
23:/etc/hosts[^/]*		--	gen_context(system_u:object_r:net_conf_t,s0)
24:/etc/hosts\.deny.*	--	gen_context(system_u:object_r:net_conf_t,s0)
25:/etc/denyhosts.*	--	gen_context(system_u:object_r:net_conf_t,s0)
26:/etc/resolv\.conf.*		gen_context(system_u:object_r:net_conf_t,s0)
27:/etc/resolv-secure.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
28:/etc/\.resolv\.conf.*	--	gen_context(system_u:object_r:net_conf_t,s0)
29:/etc/yp\.conf.*		--	gen_context(system_u:object_r:net_conf_t,s0)
30:/etc/ntp\.conf		--	gen_context(system_u:object_r:net_conf_t,s0)
36:/etc/sysconfig/network-scripts/.*resolv\.conf -- gen_context(system_u:object_r:net_conf_t,s0)
37:/etc/sysconfig/networking(/.*)? gen_context(system_u:object_r:net_conf_t,s0)
38:/etc/sysconfig/network-scripts(/.*)? gen_context(system_u:object_r:net_conf_t,s0)
39:/var/run/systemd/network(/.*)?  gen_context(system_u:object_r:net_conf_t,s0)
40:/var/run/systemd/resolve/resolv\.conf   --  gen_context(system_u:object_r:net_conf_t,s0)
41:/var/run/systemd/resolve/stub-resolv\.conf  gen_context(system_u:object_r:net_conf_t,s0)
43:/var/run/NetworkManager/resolv\.conf.*   --  gen_context(system_u:object_r:net_conf_t,s0)
45:/var/run/cloud-init(/.*)?     gen_context(system_u:object_r:net_conf_t,s0)
102:/var/run/network(/.*)?	gen_context(system_u:object_r:net_conf_t,s0)

policy/modules/system/sysnetwork.if
363:		type net_conf_t;
367:	allow $1 net_conf_t:file setattr_file_perms;
383:                type net_conf_t;
386:        allow $1 net_conf_t:file relabelfrom;
402:                type net_conf_t;
405:        allow $1 net_conf_t:file relabelto;
441:		type net_conf_t;
445:	read_files_pattern($1, net_conf_t, net_conf_t)
446:	read_lnk_files_pattern($1, net_conf_t, net_conf_t)
450:		list_dirs_pattern($1, net_conf_t, net_conf_t)
456:		list_dirs_pattern($1, net_conf_t, net_conf_t)
472:		type net_conf_t;
475:	dontaudit $1 net_conf_t:file read_file_perms;
476:	dontaudit $1 net_conf_t:lnk_file read_lnk_file_perms;
491:		type net_conf_t;
495:	allow $1 net_conf_t:file write_file_perms;
510:		type net_conf_t;
514:	allow $1 net_conf_t:file create_file_perms;
515:	allow $1 net_conf_t:lnk_file create_lnk_file_perms;
530:		type net_conf_t;
534:	allow $1 net_conf_t:file watch_file_perms;
535:	allow $1 net_conf_t:lnk_file watch_lnk_file_perms;
556:		type net_conf_t;
559:	files_etc_filetrans($1, net_conf_t, file, $2)
560:	files_etc_filetrans($1, net_conf_t, lnk_file, $2)
592:		type net_conf_t;
595:	filetrans_pattern($1, $2, net_conf_t, $3, $4)
610:		type net_conf_t;
614:	manage_files_pattern($1, net_conf_t, net_conf_t)
615:	manage_lnk_files_pattern($1, net_conf_t, net_conf_t)
630:		type net_conf_t;
634:	manage_dirs_pattern($1, net_conf_t, net_conf_t)
977:		type net_conf_t;
1026:		type net_conf_t;
1061:		type net_conf_t;
1139:		type net_conf_t;
1143:		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf")
1144:		systemd_resolved_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
1145:		systemd_resolved_pid_filetrans($1, net_conf_t, { file lnk_file }, "stub-resolv.conf")
1161:		type net_conf_t;
1165:	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
1166:	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.fp-tmp")
1167:	files_etc_filetrans($1, net_conf_t, file, "resolv.conf.fp-saved")
1168:	files_etc_filetrans($1, net_conf_t, file, "resolv-secure.conf")
1169:	files_etc_filetrans($1, net_conf_t, file, ".resolv.conf.dnssec-trigger")
1170:	files_etc_filetrans($1, net_conf_t, file, ".resolv-secure.conf.dnssec-trigger")
1171:	files_etc_filetrans($1, net_conf_t, file, "denyhosts")
1172:	files_etc_filetrans($1, net_conf_t, file, "hosts")
1173:	files_etc_filetrans($1, net_conf_t, file, "hosts.deny")
1174:	files_etc_filetrans($1, net_conf_t, file, "ethers")
1175:	files_etc_filetrans($1, net_conf_t, file, "yp.conf")
1176:	files_etc_filetrans($1, net_conf_t, file, "ntp.conf")
1177:	init_pid_filetrans($1, net_conf_t, dir, "network")
1180:		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf")
1181:		networkmanager_pid_filetrans($1, net_conf_t, file, "resolv.conf.tmp")
1237:		type net_conf_t;
1240:	files_etc_filetrans($1, net_conf_t, file)
1255:		type net_conf_t;
1258:	files_pid_filetrans($1, net_conf_t, dir, "cloud-init")

policy/modules/system/systemd.te
1139:init_named_pid_filetrans(systemd_network_generator_t, net_conf_t, dir, "network")

policy/modules/contrib/networkmanager.te
254:# in /etc created by NetworkManager will be labelled net_conf_t.
```