### PR TITLE
Fixes #35402 - label /var/lib/foreman/public httpd_sys_content_t

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -26,6 +26,7 @@
 /etc/puppetlabs/puppet/node.rb                  --  gen_context(system_u:object_r:foreman_enc_t, s0)
 
 /var/lib/foreman(/.*)?                              gen_context(system_u:object_r:foreman_lib_t,s0)
+/var/lib/foreman/public(/.*)?                       gen_context(system_u:object_r:httpd_sys_content_t,s0)
 
 /var/log/foreman(/.*)?                              gen_context(system_u:object_r:foreman_log_t,s0)
 


### PR DESCRIPTION
This is needed to allow it to serve static assets which are deployed to
/var/lib/foreman/public