### PR TITLE
Fixes #35971 - Drop requirement to set DISTRO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ VERSION=99.999
 MANCHAPTER=Foreman
 TMPDIR=local-tmp-foreman
 
-ifndef DISTRO
-$(error *** Set the DISTRO variable e.g. rhel7 or fedora21 ***)
-endif
-
 all: policies all-data
 
 load: \
@@ -70,7 +66,7 @@ foreman-proxy-selinux-disable: common/selinux-disable.sh
 	-mkdir ${TMPDIR} 2>/dev/null
 	cp $< ${<:.te=.fc} ${<:.te=.if} ${TMPDIR}/
 	sed -i 's/@@VERSION@@/${VERSION}/' ${TMPDIR}/*.te
-	$(MAKE) -C ${TMPDIR} -f /usr/share/selinux/devel/Makefile NAME=${VARIANT} DISTRO=$(DISTRO)
+	$(MAKE) -C ${TMPDIR} -f /usr/share/selinux/devel/Makefile NAME=${VARIANT}
 	mv ${TMPDIR}/$@ .
 
 %.pp.load.tmp: %.pp
@@ -110,7 +106,7 @@ consolidate-installation:
 remote-load:
 ifdef HOST
 	-rsync -qrav . --delete -e ssh --exclude .git ${HOST}:${TMPDIR}/
-	ssh ${HOST} 'cd ${TMPDIR} && sed -i s/@@VERSION@@/${VERSION}/ *.te && make reload DISTRO=${DISTRO}'
+	ssh ${HOST} 'cd ${TMPDIR} && sed -i s/@@VERSION@@/${VERSION}/ *.te && make reload'
 else
 	$(error You need to define your remote ssh hostname as HOST)
 endif

--- a/README.md
+++ b/README.md
@@ -10,16 +10,11 @@ To locally compile the policy do something like:
 
     PCY=foreman
     sed -i s/@@VERSION@@/99.9/ $PCY.te
-    make -f /usr/share/selinux/devel/Makefile load DISTRO=rhel7 NAME=$PCY
-
-Make sure you provide the correct distribution. Possible values are:
-
-* fedoraN (defines m4 macro `distro_fedoraN`)
-* rhelN (defines m4 macro `distro_rhelN`)
+    make -f /usr/share/selinux/devel/Makefile load NAME=$PCY
 
 There's a target to do compile and load policy on a remote system via ssh:
 
-    make remote-load HOST=foreman.example.com DISTRO=rhel7 NAME=foreman
+    make remote-load HOST=foreman.example.com NAME=foreman
 
 Often it is necessary to relabel relevant files and directories:
 


### PR DESCRIPTION
We no longer have any distro specific code and the shared SELinux Makefile doesn't use it either. It will now fall back to the default.

Fixes: 59536195164227307a6ac113fc5efdf74009629d