### PR TITLE
Fixes #36069 - remove old Puppet node.rb path

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -8,7 +8,6 @@
   /run/foreman.sock \
   /var/log/foreman \
   /etc/foreman \
-  /etc/puppet/node.rb \
   /etc/puppetlabs/puppet/node.rb \
   /etc/sysconfig/foreman* \
   /usr/lib/systemd/system/foreman* \


### PR DESCRIPTION
Even though `restorecon`  is passed with `-i` ignore switch, which only works if the path is valid. In newer versions of foreman, `/etc/puppet/` path is non-existent so is the error. 

To get of this error, removing the old Puppet path `/etc/puppet/node.rb`  from `foreman-selinux-relabel`  file.