### PR TITLE
make cockpit definition optional

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -40,7 +40,7 @@
 
 # Foreman Remote Execution
 
-/usr/sbin/foreman-cockpit-session       gen_context(system_u:object_r:cockpit_session_exec_t,s0)
+/usr/sbin/foreman-cockpit-session       gen_context(system_u:object_r:foreman_cockpit_session_exec_t,s0)
 
 # Foreman Hooks plugin
 

--- a/foreman.te
+++ b/foreman.te
@@ -128,9 +128,6 @@ require{
     type bin_t;
     type httpd_t;
     type websm_port_t;
-    type cockpit_ws_t;
-    type cockpit_session_t;
-    type cockpit_session_exec_t;
     type unconfined_service_t;
     type http_cache_port_t;
     type squid_port_t;
@@ -333,21 +330,35 @@ manage_dirs_pattern(foreman_rails_t, system_cronjob_tmp_t, system_cronjob_tmp_t)
 # Remote Execution
 #
 
-# Run /usr/bin/env and /usr/bin/ruby
-corecmd_exec_bin(cockpit_ws_t)
-kernel_read_system_state(cockpit_ws_t)
+# this needs to exist even if cockpit policy doesn't
+type foreman_cockpit_session_exec_t;
 
-# Connect to Foreman HTTP(s) port
-corenet_tcp_connect_http_port(cockpit_session_t)
-corenet_tcp_connect_http_port(cockpit_ws_t)
+optional_policy(`
+    gen_require(`
+        type cockpit_ws_t;
+        type cockpit_session_t;
+        type cockpit_session_exec_t;
+    ')
+    # foreman-cockpit-session needs to be labeled foreman_cockpit_session_exec_t,
+    # but we need to end up in cockpit_session_t
+    domtrans_pattern(cockpit_ws_t, foreman_cockpit_session_exec_t, cockpit_session_t)
+    domain_entry_file(cockpit_session_t, foreman_cockpit_session_exec_t)
 
-# Connect to remote Cockpit instance HTTPS port
-corenet_tcp_connect_websm_port(cockpit_session_t)
-corenet_tcp_connect_websm_port(cockpit_ws_t)
+    # Run /usr/bin/env and /usr/bin/ruby
+    corecmd_exec_bin(cockpit_ws_t)
+    kernel_read_system_state(cockpit_ws_t)
 
-# Connect to Foreman Cockpit instance HTTPS port
-corenet_tcp_connect_websm_port(httpd_t)
+    # Connect to Foreman HTTP(s) port
+    corenet_tcp_connect_http_port(cockpit_session_t)
+    corenet_tcp_connect_http_port(cockpit_ws_t)
 
+    # Connect to remote Cockpit instance HTTPS port
+    corenet_tcp_connect_websm_port(cockpit_session_t)
+    corenet_tcp_connect_websm_port(cockpit_ws_t)
+
+    # Connect to Foreman Cockpit instance HTTPS port
+    corenet_tcp_connect_websm_port(httpd_t)
+')
 
 #######################################
 #


### PR DESCRIPTION
The problem is that the cockpit policy moved to the cockpit package in EL9, not in the main selinux policy anymore.
Thus, when installing on a system without cockpit (and its policy), you get ugly errors like:

    Failed to resolve typeattributeset statement at /var/lib/selinux/targeted/tmp/modules/400/foreman/cil:66

And more importantly: the *whole* policy fails to load, leading to many issues at runtime.

To avoid this, we have to wrap the cockpit-related parts of the policy with `optional_policy` and introduce an own entrypoint that we can use in our file contexts, as there is no `optional()` for those.