### PR TITLE
drop the foreman-cockpit-session symlink rules

### DIFF
--- a/foreman.fc
+++ b/foreman.fc
@@ -41,7 +41,6 @@
 # Foreman Remote Execution
 
 /usr/sbin/foreman-cockpit-session       gen_context(system_u:object_r:cockpit_session_exec_t,s0)
-/usr/share/gems/gems/foreman_remote_execution-.*/extra/cockpit/foreman-cockpit-session -- gen_context(system_u:object_r:cockpit_session_exec_t,s0)
 
 # Foreman Hooks plugin
 

--- a/foreman.te
+++ b/foreman.te
@@ -333,10 +333,6 @@ manage_dirs_pattern(foreman_rails_t, system_cronjob_tmp_t, system_cronjob_tmp_t)
 # Remote Execution
 #
 
-# File /usr/sbin/foreman-cockpit-session is a symlink
-read_lnk_files_pattern(cockpit_ws_t, cockpit_session_exec_t, cockpit_session_exec_t)
-read_lnk_files_pattern(cockpit_session_t, cockpit_session_exec_t, cockpit_session_exec_t)
-
 # Run /usr/bin/env and /usr/bin/ruby
 corecmd_exec_bin(cockpit_ws_t)
 kernel_read_system_state(cockpit_ws_t)


### PR DESCRIPTION
Since rubygem-foreman_remote_execution-12.0.5-3[1] we do not have the symlink from /usr/sbin to /usr/share/gems/…  anymore, so we also don't need to do any of the labeling and "can read links" things in the policy.

[1] https://github.com/theforeman/foreman-packaging/commit/f4ac262a92d172540332554f83d50d828a3c9737