### PR TITLE
Fixes #37999 - allow smart-proxy with PuppetCA to read some etc files

### DIFF
--- a/foreman-proxy.fc
+++ b/foreman-proxy.fc
@@ -23,3 +23,5 @@
 /var/run/foreman-proxy(/.*)? gen_context(system_u:object_r:foreman_proxy_var_run_t,s0)
 
 /var/spool/foreman-proxy(/.*)? gen_context(system_u:object_r:foreman_proxy_spool_t,s0)
+
+/etc/foreman-proxy(/.*)? gen_context(system_u:object_r:foreman_proxy_etc_t,s0)

--- a/foreman-proxy.te
+++ b/foreman-proxy.te
@@ -101,6 +101,12 @@ manage_dirs_pattern(foreman_proxy_t, foreman_proxy_spool_t, foreman_proxy_spool_
 manage_files_pattern(foreman_proxy_t, foreman_proxy_spool_t, foreman_proxy_spool_t)
 files_spool_filetrans(foreman_proxy_t, foreman_proxy_spool_t, { dir file })
 
+
+# etc files support
+type foreman_proxy_etc_t;
+files_type(foreman_proxy_etc_t)
+read_files_pattern(foreman_proxy_t, foreman_proxy_etc_t, foreman_proxy_etc_t)
+
 # starting via /bin/env
 corecmd_read_bin_symlinks(foreman_proxy_t)
 


### PR DESCRIPTION
Dear maintainer,

The current foreman-proxy SELinux policy isn't working when trying to use the PuppetCA feature. The proxy tries to read some files in `/etc/foreman-proxy` but is not allowed:

```
type=AVC msg=audit(1721979897.417:100790): avc:  denied  { read } for  pid=731469 comm="smart-proxy" name="puppetca_hostname_whitelisting.yml" dev="dm-0" ino=33791767 scontext=system_u:system_r:foreman_proxy_t:s0 tcontext=system_u:object_r:hostname_etc_t:s0 tclass=file permissive=1
type=AVC msg=audit(1721979897.417:100790): avc:  denied  { open } for  pid=731469 comm="smart-proxy" path="/etc/foreman-proxy/settings.d/puppetca_hostname_whitelisting.yml" dev="dm-0" ino=33791767 scontext=system_u:system_r:foreman_proxy_t:s0 tcontext=system_u:object_r:hostname_etc_t:s0 tclass=file permissive=1
type=AVC msg=audit(1721979897.417:100791): avc:  denied  { ioctl } for  pid=731469 comm="smart-proxy" path="/etc/foreman-proxy/settings.d/puppetca_hostname_whitelisting.yml" dev="dm-0" ino=33791767 ioctlcmd=0x5401 scontext=system_u:system_r:foreman_proxy_t:s0 tcontext=system_u:object_r:hostname_etc_t:s0 tclass=file permissive=1
type=AVC msg=audit(1721979897.417:100792): avc:  denied  { getattr } for  pid=731469 comm="smart-proxy" path="/etc/foreman-proxy/settings.d/puppetca_hostname_whitelisting.yml" dev="dm-0" ino=33791767 scontext=system_u:system_r:foreman_proxy_t:s0 tcontext=system_u:object_r:hostname_etc_t:s0 tclass=file permissive=1
```

To make this work, I've created a new file type `foreman_proxy_etc_t` and added the minimum privileges.

Regards