### PR TITLE
Fixes #38583: Allow mounting postgres as socket to container

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -274,6 +274,14 @@ optional_policy(`
     postgresql_stream_connect(foreman_rails_t)
 ')
 
+# Allow containers to connect to PostgreSQL
+optional_policy(`
+    gen_require(`
+        type container_t;
+    ')
+    postgresql_stream_connect(container_t)
+')
+
 # Connecting to Redis
 corenet_tcp_connect_redis_port(foreman_rails_t)
 


### PR DESCRIPTION
This is part of the IoP work where the containers are mounting Postgres as a socket. The denials:

```
type=AVC msg=audit(1752541397.045:4832): avc:  denied  { write } for  pid=49619 comm="python3.12" name=".s.PGSQL.5432" dev="tmpfs" ino=1528 scontext=system_u:system_r:container_t:s0:c605,c856 tcontext=system_u:object_r:postgresql_var_run_t:s0 tclass=sock_file permissive=1
type=AVC msg=audit(1752541397.045:4832): avc:  denied  { connectto } for  pid=49619 comm="python3.12" path="/run/postgresql/.s.PGSQL.5432" scontext=system_u:system_r:container_t:s0:c605,c856 tcontext=system_u:system_r:postgresql_t:s0 tclass=unix_stream_socket permissive=1
```