### PR TITLE
Fixes #38589: Allow kafka container access to /var/lib/kafka

### DIFF
--- a/foreman-selinux-relabel
+++ b/foreman-selinux-relabel
@@ -17,6 +17,7 @@
   /etc/cron.d/foreman* \
   /usr/libexec/foreman \
   /usr/sbin/foreman-cockpit-session \
-  /usr/bin/websockify
+  /usr/bin/websockify \
+  /var/lib/kafka
 
 exit 0

--- a/foreman.fc
+++ b/foreman.fc
@@ -49,3 +49,7 @@
 # Foreman Tasks plugin
 
 /usr/share/gems/gems/foreman-tasks-.*/bin/foreman-tasks -- gen_context(system_u:object_r:foreman_tasks_exec_t,s0)
+
+# Kafka container file contexts
+
+/var/lib/kafka(/.*)?                    gen_context(system_u:object_r:container_var_lib_t,s0)


### PR DESCRIPTION
Addressing this:

```
SELinux is preventing /usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el9.x86_64/bin/java from add_name access on the directory /opt/kafka/(null).

*****  Plugin restorecon (94.8 confidence) suggests   ************************

If you want to fix the label. 
/opt/kafka/(null) default label should be usr_t.
Then you can run restorecon. The access attempt may have been stopped due to insufficient permissions to access a parent directory in which case try to change the following command accordingly.
Do
# /sbin/restorecon -v /opt/kafka/(null)

*****  Plugin catchall_labels (5.21 confidence) suggests   *******************

If you want to allow java to have add_name access on the (null) directory
Then you need to change the label on /opt/kafka/(null)
Do
# semanage fcontext -a -t FILE_TYPE '/opt/kafka/(null)'
where FILE_TYPE is one of the following: bpf_t, cgroup_t, container_file_t, container_var_lib_t, fusefs_t, hugetlbfs_t, nfs_t, svirt_home_t, tmpfs_t, virt_home_t.
Then execute:
restorecon -v '/opt/kafka/(null)'


*****  Plugin catchall (1.44 confidence) suggests   **************************

If you believe that java should be allowed add_name access on the (null) directory by default.
Then you should report this as a bug.
You can generate a local policy module to allow this access.
Do
allow this access for now by executing:
# ausearch -c 'kafka-scheduler' --raw | audit2allow -M my-kafkascheduler
# semodule -X 300 -i my-kafkascheduler.pp


Additional Information:
Source Context                system_u:system_r:container_t:s0:c783,c898
Target Context                system_u:object_r:var_lib_t:s0:c783,c898
Target Objects                /opt/kafka/(null) [ dir ]
Source                        kafka-scheduler
Source Path                   /usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el9.x8
                              6_64/bin/java
Port                          <Unknown>
Host                          ip-10-0-168-161.rhos-01.prod.psi.rdu2.redhat.com
Source RPM Packages           
Target RPM Packages           
SELinux Policy RPM            selinux-policy-targeted-38.1.53-5.el9_6.noarch
Local Policy RPM              selinux-policy-targeted-38.1.53-5.el9_6.noarch
Selinux Enabled               True
Policy Type                   targeted
Enforcing Mode                Permissive
Host Name                     ip-10-0-168-161.rhos-01.prod.psi.rdu2.redhat.com
Platform                      Linux
                              ip-10-0-168-161.rhos-01.prod.psi.rdu2.redhat.com
                              5.14.0-570.24.1.el9_6.x86_64 #1 SMP
                              PREEMPT_DYNAMIC Sat Jun 21 15:37:27 EDT 2025
                              x86_64 x86_64
Alert Count                   43
First Seen                    2025-07-18 09:50:57 EDT
Last Seen                     2025-07-18 12:49:27 EDT
Local ID                      bdd8707e-8faf-4818-9581-963a4242a3bf

Raw Audit Messages
type=AVC msg=audit(1752857367.74:17298): avc:  denied  { write } for  pid=123662 comm="kafka-scheduler" name="data" dev="vda4" ino=100901796 scontext=system_u:system_r:container_t:s0:c783,c898 tcontext=system_u:object_r:var_lib_t:s0:c783,c898 tclass=dir permissive=1


type=AVC msg=audit(1752857367.74:17298): avc:  denied  { add_name } for  pid=123662 comm="kafka-scheduler" name="replication-offset-checkpoint.tmp" scontext=system_u:system_r:container_t:s0:c783,c898 tcontext=system_u:object_r:var_lib_t:s0:c783,c898 tclass=dir permissive=1


type=SYSCALL msg=audit(1752857367.74:17298): arch=x86_64 syscall=openat success=yes exit=439 a0=ffffff9c a1=7f5c4000f280 a2=241 a3=1b6 items=4 ppid=123660 pid=123662 auid=4294967295 uid=1001 gid=0 euid=1001 suid=1001 fsuid=1001 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm=kafka-scheduler exe=/usr/lib/jvm/java-17-openjdk-17.0.13.0.11-3.el9.x86_64/bin/java subj=system_u:system_r:container_t:s0:c783,c898 key=(null)

type=CWD msg=audit(1752857367.74:17298): cwd=/opt/kafka

type=PATH msg=audit(1752857367.74:17298): item=0 name=(null) inode=100901796 dev=fc:04 mode=040755 ouid=1001 ogid=1001 rdev=00:00 obj=system_u:object_r:var_lib_t:s0:c783,c898 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

type=PATH msg=audit(1752857367.74:17298): item=1 name=(null) nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

type=PATH msg=audit(1752857367.74:17298): item=2 name=(null) inode=100901796 dev=fc:04 mode=040755 ouid=1001 ogid=1001 rdev=00:00 obj=system_u:object_r:var_lib_t:s0:c783,c898 nametype=PARENT cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

type=PATH msg=audit(1752857367.74:17298): item=3 name=(null) inode=100901763 dev=fc:04 mode=0100644 ouid=1001 ogid=0 rdev=00:00 obj=system_u:object_r:var_lib_t:s0:c783,c898 nametype=CREATE cap_fp=0 cap_fi=0 cap_fe=0 cap_fver=0 cap_frootid=0

Hash: kafka-scheduler,container_t,var_lib_t,dir,add_name
```