### PR TITLE
Don't call corecmd_exec_bin(foreman_proxy_t) inside the PuppetCA tunable

### DIFF
--- a/foreman-proxy.te
+++ b/foreman-proxy.te
@@ -203,7 +203,6 @@ tunable_policy(`foreman_proxy_manage_puppetca', `
     allow foreman_proxy_t puppet_log_t:dir search_dir_perms;
     allow foreman_proxy_t puppet_var_run_t:dir search_dir_perms;
     kernel_read_kernel_sysctls(foreman_proxy_t)
-    corecmd_exec_bin(foreman_proxy_t)
     corecmd_exec_shell(foreman_proxy_t)
     dev_read_urand(foreman_proxy_t)
     dev_search_sysfs(foreman_proxy_t)


### PR DESCRIPTION
We call it outside already, so it should not be needed, and for some reason including it make the policy fail to compile on EL10 [1][2].

Given we don't deploy the proxy policy at all, this doesn't matter much anyway.

[1] https://redhat.atlassian.net/browse/RHEL-141858
[2] https://github.com/fedora-selinux/selinux-policy/commit/07f0cb4f38ece8ba3a8cdaab6acf8b469680df99