### PR TITLE
Fixes #39646 - Allow sshpass in the Foreman domain

### DIFF
--- a/foreman.te
+++ b/foreman.te
@@ -61,7 +61,7 @@ gen_tunable(foreman_rails_can_connect_openstack, true)
 
 ## <desc>
 ## <p>
-## Determine whether Ruby on Rails can execute ssh (needed for qemu+ssh libvirt connection).
+## Determine whether Ruby on Rails can execute ssh (needed for qemu+ssh libvirt connection and SSH provisioning).
 ## </p>
 ## </desc>
 gen_tunable(foreman_rails_can_spawn_ssh, true)
@@ -400,6 +400,10 @@ optional_policy(`
 
         ssh_exec(foreman_rails_t)
         ssh_read_user_home_files(foreman_rails_t)
+
+        # sshpass needs pty for password authentication
+        term_use_ptmx(foreman_rails_t)
+        term_use_generic_ptys(foreman_rails_t)
     ')
 ')
 


### PR DESCRIPTION
For https://github.com/theforeman/foreman/pull/11176 we need to allow execution of `ssh`. This is already allowed in the policy and the only thing left was allowing `sshpass` to work. The sshpass binary is labeled bin_t and already executable via corecmd_exec_bin, but it needs to allocate a pseudo-terminal — SSH reads passwords from /dev/tty, even when the password is passed via environment variable (`sshpass -e` in our use case).

Replaces https://github.com/theforeman/foreman-selinux/pull/181 which allows transition to `ssh_t` domain but that one is quite empty in RHEL9 and unusable. Therefore, using the current approach which allows execution of `ssh` within the Foreman domain is easier. We could revisit the transition for RHEL10+ 

Expanded macros against c9s selinux branch:

```
[lzapleta@yuki ~]$ semacro lookup term_use_ptmx
interface term_use_ptmx  # modules/kernel/terminal.if:877
interface(`term_use_ptmx',`
	gen_require(`
		type ptmx_t;
	')

	dev_list_all_dev_nodes($1)
	allow $1 ptmx_t:chr_file rw_file_perms;
')

[lzapleta@yuki ~]$ semacro lookup term_use_generic_ptys
interface term_use_generic_ptys  # modules/kernel/terminal.if:760
interface(`term_use_generic_ptys',`
	gen_require(`
		type devpts_t;
	')

	dev_list_all_dev_nodes($1)
	allow $1 devpts_t:dir list_dir_perms;
	allow $1 devpts_t:chr_file { rw_term_perms lock append };
')
```